### PR TITLE
Cluster mode

### DIFF
--- a/config.js
+++ b/config.js
@@ -313,6 +313,11 @@ var conf = convict({
       default: "target_distribution"
     }
   },
+  cluster: {
+    doc: "If true, CDN runs in cluster mode, starting a worker for each CPU core",
+    format: Boolean,
+    default: false
+  },
   gzip: {
     doc: "If true, uses gzip compression and adds a 'Content-Encoding:gzip' header to the response",
     format: Boolean,

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -69,7 +69,7 @@ function onListening(server) {
   var address = server.address()
 
   if (env !== 'test') {
-    var startText = '  ----------------------------\n';
+    var startText = '\n  ----------------------------\n';
     startText += '  Started \'DADI CDN\'\n';
     startText += '  ----------------------------\n';
     startText += '  Server:      '.green + address.address + ':' + address.port + '\n';

--- a/index.js
+++ b/index.js
@@ -67,15 +67,17 @@ function restartWorkers() {
   }
 
   workerIds.forEach(function(wid) {
-    cluster.workers[wid].send({
-      type: 'shutdown',
-      from: 'master'
-    })
+    if (cluster.workers[wid]) {
+      cluster.workers[wid].send({
+        type: 'shutdown',
+        from: 'master'
+      })
 
-    setTimeout(function() {
-      if(cluster.workers[wid]) {
-        cluster.workers[wid].kill('SIGKILL')
-      }
-    }, 5000)
+      setTimeout(function() {
+        if(cluster.workers[wid]) {
+          cluster.workers[wid].kill('SIGKILL')
+        }
+      }, 5000)
+    }
   })
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,81 @@
-var app = module.exports = require('./dadi/lib');
-app.start(function() {});
+var chokidar = require('chokidar')
+var cluster = require('cluster')
+var config = require('./config')
+var fs = require('fs')
+var path = require('path')
 
+require('console-stamp')(console, 'yyyy-mm-dd HH:MM:ss.l')
+
+if (config.get('cluster')) {
+  if (cluster.isMaster) {
+    var numWorkers = require('os').cpus().length
+    console.log('Master cluster setting up ' + numWorkers + ' workers...')
+
+    for(var i = 0; i < numWorkers; i++) {
+      cluster.fork()
+    }
+
+    cluster.on('online', function(worker) {
+      console.log('Worker ' + worker.process.pid + ' is online')
+    })
+
+    cluster.on('exit', function(worker, code, signal) {
+      console.log('Worker ' + worker.process.pid + ' died with code: ' + code + ', and signal: ' + signal)
+      console.log('Starting a new worker')
+      cluster.fork();
+    })
+
+    var watcher = chokidar.watch(process.cwd(), {
+      depth: 0,
+      ignored: /[\/\\]\./,
+      ignoreInitial: true
+    })
+
+    watcher.on('add', function(filePath) {
+      if (path.basename(filePath) === 'restart.cdn') {
+        console.log('Shutdown requested')
+        fs.unlinkSync(filePath)
+        restartWorkers()
+      }
+    })
+  }
+  else {
+    var app = module.exports = require('./dadi/lib')
+    app.start(function() {
+      console.log('Process ' + process.pid + ' is listening for incoming requests')
+
+      process.on('message', function(message) {
+        if (message.type === 'shutdown') {
+          console.log('Process ' + process.pid + ' is shutting down...')
+          process.exit(0);
+        }
+      })
+    })
+  }
+} else {
+  var app = module.exports = require('./dadi/lib')
+  app.start(function() {
+    console.log('Process ' + process.pid + ' is listening for incoming requests')
+  })
+}
+
+function restartWorkers() {
+  var wid, workerIds = []
+
+  for(wid in cluster.workers) {
+    workerIds.push(wid)
+  }
+
+  workerIds.forEach(function(wid) {
+    cluster.workers[wid].send({
+      type: 'shutdown',
+      from: 'master'
+    })
+
+    setTimeout(function() {
+      if(cluster.workers[wid]) {
+        cluster.workers[wid].kill('SIGKILL')
+      }
+    }, 5000)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/cdn",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A high performance, just-in-time asset manipulation and delivery layer designed as a modern content distribution solution.",
   "scripts": {
     "init": "validate-commit-msg",
@@ -16,10 +16,12 @@
     "aws-sdk": "2.3.0",
     "bluebird": "latest",
     "body-parser": "~1.14.1",
+    "chokidar": "^1.5.1",
     "cloudfront": "~0.3.3",
     "color-thief": "~2.2.1",
     "colors": "^1.1.2",
     "concat-stream": "^1.5.1",
+    "console-stamp": "^0.2.2",
     "convict": "^1.0.1",
     "exif": "^0.6.0",
     "exif2": "0.0.1",


### PR DESCRIPTION
This PR adds support for running CDN in cluster mode. 

1. Add to config: `"cluster": true`
2. To restart workers without restarting the whole app, run `touch restart.cdn` from the app directory

