### PR TITLE
Feature: status tests

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -172,8 +172,16 @@ Server.prototype.stop = function (done) {
   this.readyState = 3
 
   this.server.close(function (err) {
-    self.readyState = 0
-    done && done(err)
+    // if statusServer is running in standalone, close that too
+    if (self.statusServer) {
+      self.statusServer.close(function (err) {
+        self.readyState = 0
+        done && done(err)
+      })
+    } else {
+      self.readyState = 0
+      done && done(err)
+    }
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "fakeredis": "^1.0.2",
     "istanbul": "^0.4.4",
     "istanbul-cobertura-badger": "^1.2.1",
+    "lodash": "^4.13.1",
     "mocha": "~1.21.3",
     "proxyquire": "~1.7.4",
     "should": "~4.0.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "fakeredis": "^1.0.2",
     "istanbul": "^0.4.4",
     "istanbul-cobertura-badger": "^1.2.1",
-    "lodash": "^4.13.1",
     "mocha": "~1.21.3",
     "proxyquire": "~1.7.4",
     "should": "~4.0.4",

--- a/test/acceptance/status.js
+++ b/test/acceptance/status.js
@@ -1,0 +1,216 @@
+var _ = require('lodash')
+var fs = require('fs')
+var path = require('path')
+var should = require('should')
+var sinon = require('sinon')
+var request = require('supertest')
+
+var cache = require(__dirname + '/../../dadi/lib/cache')
+var config = require(__dirname + '/../../config')
+var help = require(__dirname + '/help')
+var app = require(__dirname + '/../../dadi/lib/')
+
+var defaultConfig = {
+  "status": {
+    "enabled": true,
+    "requireAuthentication": true,
+    "standalone": false,
+    "port": 8112,
+    "routes": [
+      {
+        "route": "/test.jpg?format=png&quality=50&width=800&height=600",
+        "expectedResponseTime": 0.025
+      }
+    ]
+  }
+}
+
+function updateConfigAndReloadApp (configOverride) {
+  delete require.cache[__dirname + '/../../config']
+  config = require(__dirname + '/../../config')
+
+  var testConfigString = fs.readFileSync(config.configPath())
+  var newTestConfig = _.mergeWith({}, JSON.parse(testConfigString), defaultConfig, configOverride)
+
+  fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+  config.loadFile(config.configPath())
+
+  // reload the app so it picks up config changes
+  delete require.cache[require.resolve(__dirname + '/../../dadi/lib')]
+  app = require(__dirname + '/../../dadi/lib')
+}
+
+describe('Status', function () {
+  var statusRoute = '/api/status' // TODO move to config
+  var bearerToken
+
+  this.timeout(10000)
+
+  before(function (done) {
+    // make sure config is reset properly so these tests run fine
+    updateConfigAndReloadApp({})
+    done()
+  })
+
+  after(function (done) {
+    // make sure config is reset properly so other tests run ok
+    // it's essential that status.standalone is disabled
+    updateConfigAndReloadApp({})
+    done()
+  })
+
+  describe('Integrated', function () {
+
+    describe('Authenticated', function () {
+
+      beforeEach(function (done) {
+        app.start(function (err) {
+          if (err) return done(err)
+
+          // give http.Server a moment to finish starting up
+          // then grab a bearer token from it
+          setTimeout(function () {
+            help.getBearerToken(function (err, token) {
+              if (err) return done(err)
+              bearerToken = token
+              done()
+            })
+          }, 500)
+        })
+      })
+
+      afterEach(function (done) {
+        help.clearCache()
+        app.stop(done)
+      })
+
+      it('should return error if no token is given', function (done) {
+        var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+        client
+          .post(statusRoute)
+          .expect('content-type', 'application/json')
+          .expect(401, done)
+      })
+
+      it('should return ok if token is given', function (done) {
+        var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+        client
+          .post(statusRoute)
+          .set('Authorization', 'Bearer ' + bearerToken)
+          .expect('content-type', 'application/json')
+          .expect(200, done)
+      })
+
+    })
+
+    describe('Unauthenticated', function () {
+
+      beforeEach(function (done) {
+        updateConfigAndReloadApp({ "status": { "requireAuthentication": false } })
+
+        app.start(function (err) {
+          if (err) return done(err)
+
+          // give http.Server a moment to finish starting up
+          setTimeout(function () {
+            done()
+          }, 500)
+        })
+      })
+
+      afterEach(function (done) {
+        help.clearCache()
+        app.stop(done)
+      })
+
+      it('should return ok even if no token is given', function (done) {
+        var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+        client
+          .post(statusRoute)
+          .expect('content-type', 'application/json')
+          .expect(200, done)
+      })
+
+    })
+
+  })
+
+  describe('Standalone', function () {
+
+    describe('Authenticated', function () {
+
+      beforeEach(function (done) {
+        updateConfigAndReloadApp({ "status": { "standalone": true } })
+
+        app.start(function (err) {
+          if (err) return done(err)
+
+          // give http.Server a moment to finish starting up
+          // then grab a bearer token from it
+          setTimeout(function () {
+            help.getBearerToken(function (err, token) {
+              if (err) return done(err)
+              bearerToken = token
+              done()
+            })
+          }, 500)
+        })
+      })
+
+      afterEach(function (done) {
+        help.clearCache()
+        app.stop(done)
+      })
+
+      it('should return error if no token is given', function (done) {
+        var client = request('http://' + config.get('server.host') + ':' + config.get('status.port'))
+        client
+          .post(statusRoute)
+          .expect('content-type', 'application/json')
+          .expect(401, done)
+      })
+
+      it('should return ok if token is given', function (done) {
+        var client = request('http://' + config.get('server.host') + ':' + config.get('status.port'))
+        client
+          .post(statusRoute)
+          .set('Authorization', 'Bearer ' + bearerToken)
+          .expect('content-type', 'application/json')
+          .expect(200, done)
+      })
+
+    })
+
+    describe('Unauthenticated', function () {
+
+      beforeEach(function (done) {
+        updateConfigAndReloadApp({ "status": { "standalone": true, "requireAuthentication": false } })
+
+        app.start(function (err) {
+          if (err) return done(err)
+
+          // give http.Server a moment to finish starting up
+          setTimeout(function () {
+            done()
+          }, 500)
+        })
+      })
+
+      afterEach(function (done) {
+        help.clearCache()
+        app.stop(done)
+      })
+
+      it('should return ok even if no token is given', function (done) {
+        var client = request('http://' + config.get('server.host') + ':' + config.get('status.port'))
+        client
+          .post(statusRoute)
+          .expect('content-type', 'application/json')
+          .expect(200, done)
+      })
+
+    })
+
+  })
+
+})


### PR DESCRIPTION
Two commits in this PR.

The first fixes an issue just with testing, where the Server.prototype.close wasn't closing the standalone server, causing EADDRINUSE errors. The second is the addition of some simple acceptance tests to make sure that the endpoint works and that authentication works too.

Wasn't sure how thorough the acceptance tests should be so happy to add more to this is required. 

The thing which tripped me up on this particular issue was that the app loads the config from file when it runs, but the tests only ever have one instance of app running. Rewriting the config made no difference to the current set of tests, until I ran it again. By invalidating the require cache, I could reload the app which would pickup the config changes. :champagne: