### PR TITLE
feature: config env vars

### DIFF
--- a/config.js
+++ b/config.js
@@ -84,17 +84,20 @@ var conf = convict({
     accessKeyId: {
       doc: '',
       format: String,
-      default: ''
+      default: '',
+      env: 'AWS_ACCESS_KEY'
     },
     secretAccessKey: {
       doc: '',
       format: String,
-      default: ''
+      default: '',
+      env: 'AWS_SECRET_KEY'
     },
     region: {
       doc: '',
       format: String,
-      default: ''
+      default: '',
+      env: 'AWS_REGION'
     }
   },
   images: {
@@ -119,22 +122,26 @@ var conf = convict({
       accessKey: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_ACCESS_KEY'
       },
       secretKey: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_SECRET_KEY'
       },
       bucketName: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_BUCKET_NAME'
       },
       region: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_REGION'
       }
     },
     remote: {
@@ -172,22 +179,26 @@ var conf = convict({
       accessKey: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_ACCESS_KEY'
       },
       secretKey: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_SECRET_KEY'
       },
       bucketName: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_BUCKET_NAME'
       },
       region: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'AWS_S3_REGION'
       }
     },
     remote: {
@@ -230,17 +241,20 @@ var conf = convict({
       host: {
         doc: 'The Redis server host',
         format: String,
-        default: ''
+        default: '',
+        env: 'REDIS_HOST'
       },
       port: {
         doc: 'The port for the Redis server',
         format: 'port',
-        default: 6379
+        default: 6379,
+        env: 'REDIS_PORT'
       },
       password: {
         doc: '',
         format: String,
-        default: ''
+        default: '',
+        env: 'REDIS_PASSWORD'
       }
     }
   },
@@ -310,17 +324,20 @@ var conf = convict({
     clientId: {
       doc: '',
       format: String,
-      default: '1235488'
+      default: '1235488',
+      env: "AUTH_TOKEN_ID"
     },
     secret: {
       doc: '',
       format: String,
-      default: 'asd544see68e52'
+      default: 'asd544see68e52',
+      env: "AUTH_TOKEN_SECRET"
     },
     tokenTtl: {
       doc: '',
       format: Number,
-      default: 1800
+      default: 1800,
+      env: "AUTH_TOKEN_TTL"
     }
   },
   cloudfront: {
@@ -332,17 +349,20 @@ var conf = convict({
     accessKey: {
       doc: '',
       format: String,
-      default: 'AKIAJJHIE6YB7FVGVL7Q'
+      default: 'AKIAJJHIE6YB7FVGVL7Q',
+      env: "CLOUDFRONT_ACCESS_KEY"
     },
     secretKey: {
       doc: '',
       format: String,
-      default: 'OvIoiLgxQZszDuGCr5YWqKE/mNKlgSop+RqrkBTN'
+      default: 'OvIoiLgxQZszDuGCr5YWqKE/mNKlgSop+RqrkBTN',
+      env: "CLOUDFRONT_SECRET_KEY"
     },
     distribution: {
       doc: '',
       format: String,
-      default: 'target_distribution'
+      default: 'target_distribution',
+      env: "CLOUDFRONT_DISTRIBUTION"
     }
   },
   cluster: {

--- a/config.js
+++ b/config.js
@@ -123,25 +123,25 @@ var conf = convict({
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_ACCESS_KEY'
+        env: 'AWS_S3_IMAGES_ACCESS_KEY'
       },
       secretKey: {
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_SECRET_KEY'
+        env: 'AWS_S3_IMAGES_SECRET_KEY'
       },
       bucketName: {
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_BUCKET_NAME'
+        env: 'AWS_S3_IMAGES_BUCKET_NAME'
       },
       region: {
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_REGION'
+        env: 'AWS_S3_IMAGES_REGION'
       }
     },
     remote: {
@@ -180,25 +180,25 @@ var conf = convict({
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_ACCESS_KEY'
+        env: 'AWS_S3_ASSETS_ACCESS_KEY'
       },
       secretKey: {
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_SECRET_KEY'
+        env: 'AWS_S3_ASSETS_SECRET_KEY'
       },
       bucketName: {
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_BUCKET_NAME'
+        env: 'AWS_S3_ASSETS_BUCKET_NAME'
       },
       region: {
         doc: '',
         format: String,
         default: '',
-        env: 'AWS_S3_REGION'
+        env: 'AWS_S3_ASSETS_REGION'
       }
     },
     remote: {


### PR DESCRIPTION
As per https://github.com/dadi/cdn/issues/38

Environment variables hooked up are:

AWS_ACCESS_KEY
AWS_SECRET_KEY
AWS_REGION

AWS_S3_IMAGES_ACCESS_KEY
AWS_S3_IMAGES_SECRET_KEY
AWS_S3_IMAGES_BUCKET_NAME
AWS_S3_IMAGES_REGION

AWS_S3_ASSETS_ACCESS_KEY
AWS_S3_ASSETS_SECRET_KEY
AWS_S3_ASSETS_BUCKET_NAME
AWS_S3_ASSETS_REGION

REDIS_HOST
REDIS_PORT
REDIS_PASSWORD

AUTH_TOKEN_ID
AUTH_TOKEN_SECRET
AUTH_TOKEN_TTL

CLOUDFRONT_ACCESS_KEY
CLOUDFRONT_SECRET_KEY
CLOUDFRONT_DISTRIBUTION

I've added a few in there that aren't sensitive but are part of a set which I think you'd want to be able to set from environment variables anyway. Also, I've mapped the auth token, but I'm not sure if this is something which will tie in with some central service later on?

P.S. I did originally share the AWS S3 env vars between images & assets, but tests didn't like that so I've split them out now.