### PR TITLE
Cache control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DADI CDN
 
-[![npm (scoped)](https://img.shields.io/npm/v/@dadi/cdn.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/cdn)&nbsp;[![coverage](https://img.shields.io/badge/coverage-75%25-yellow.svg?style=flat-square)](https://github.com/dadi/cdn)&nbsp;[![Build](http://ci.dadi.technology/dadi/cdn/badge?branch=master&service=shield)](http://ci.dadi.technology/dadi/cdn)
+[![npm (scoped)](https://img.shields.io/npm/v/@dadi/cdn.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/cdn)&nbsp;[![coverage](https://img.shields.io/badge/coverage-76%25-yellow.svg?style=flat-square)](https://github.com/dadi/cdn)&nbsp;[![Build](http://ci.dadi.technology/dadi/cdn/badge?branch=master&service=shield)](http://ci.dadi.technology/dadi/cdn)
 
 ## Overview
 

--- a/config.js
+++ b/config.js
@@ -244,18 +244,6 @@ var conf = convict({
       }
     }
   },
-  clientCache: {
-    cacheControl: {
-      doc: '',
-      format: String,
-      default: 'public, max-age=3600'
-    },
-    etag: {
-      doc: '',
-      format: String,
-      default: '15f0fff99ed5aae4edffdd6496d7131f'
-    }
-  },
   status: {
   	enabled: {
       doc: "If true, status endpoint is enabled.",
@@ -361,6 +349,26 @@ var conf = convict({
     doc: "If true, uses gzip compression and adds a 'Content-Encoding:gzip' header to the response",
     format: Boolean,
     default: true
+  },
+  headers: {
+    useGzipCompression: {
+      doc: "If true, uses gzip compression and adds a 'Content-Encoding:gzip' header to the response.",
+      format: Boolean,
+      default: true
+    },
+    cacheControl: {
+      doc: "A set of cache control headers based on specified mimetypes or paths",
+      format: Object,
+      default: {
+        "default": "public, max-age=3600",
+        "paths": [],
+        "mimetypes": [
+          {"text/css": "public, max-age=86400"},
+          {"text/javascript": "public, max-age=86400"},
+          {"application/javascript": "public, max-age=86400"}
+        ]
+      }
+    }
   },
   feedback: {
     doc: '',

--- a/config/config.development.json.sample
+++ b/config/config.development.json.sample
@@ -56,10 +56,6 @@
       "port": 6379
     }
   },
-  "clientCache": {
-    "cacheControl": "public, max-age=3600",
-    "etag": "15f0fff99ed5aae4edffdd6496d7131f"
-  },
   "security": {
     "maxWidth": 2048,
     "maxHeight": 1024

--- a/config/config.production.json.sample
+++ b/config/config.production.json.sample
@@ -68,10 +68,6 @@
       "port": 6379
     }
   },
-  "clientCache": {
-    "cacheControl": "public, max-age=3600",
-    "etag": "15f0fff99ed5aae4edffdd6496d7131f"
-  },
   "security": {
     "maxWidth": 2048,
     "maxHeight": 1024

--- a/config/config.qa.json.sample
+++ b/config/config.qa.json.sample
@@ -56,10 +56,6 @@
       "port": 6379
     }
   },
-  "clientCache": {
-    "cacheControl": "public, max-age=3600",
-    "etag": "15f0fff99ed5aae4edffdd6496d7131f"
-  },
   "security": {
     "maxWidth": 2048,
     "maxHeight": 1024

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -60,10 +60,6 @@
       "port": 6379
     }
   },
-  "clientCache": {
-    "cacheControl": "public, max-age=3600",
-    "etag": "15f0fff99ed5aae4edffdd6496d7131f"
-  },
   "security": {
     "maxWidth": 2048,
     "maxHeight": 1024

--- a/dadi/lib/handlers/asset.js
+++ b/dadi/lib/handlers/asset.js
@@ -22,7 +22,8 @@ var AssetHandler = function (format, req) {
   this.supportedExtensions = ['ttf', 'otf', 'woff', 'svg', 'eot']
   this.format = format
   this.compress = '0'
-  this.factory = Object.create(StorageFactory)
+  this.storageFactory = Object.create(StorageFactory)
+  this.storageHandler = null
   this.cache = Cache()
 
   this.req = req
@@ -83,9 +84,9 @@ AssetHandler.prototype.get = function () {
         return resolve(stream)
       }
 
-      var storage = self.factory.create('asset', self.fullUrl, self.hasQuery)
+      self.storageHandler = self.storageFactory.create('asset', self.fullUrl, self.hasQuery)
 
-      storage.get().then(function (stream) {
+      self.storageHandler.get().then(function (stream) {
         // compress, returns stream
         self.compressFile(stream).then(function (stream) {
           // cache, returns stream
@@ -164,6 +165,16 @@ AssetHandler.prototype.contentType = function () {
   else if (this.fileExt === 'woff') {
     return 'application/font-woff'
   }
+}
+
+AssetHandler.prototype.getFilename = function () {
+  return this.fileName
+}
+
+AssetHandler.prototype.getLastModified = function () {
+  if (!this.storageHandler || !this.storageHandler.getLastModified) return null
+
+  return this.storageHandler.getLastModified()
 }
 
 module.exports = function (format, req) {

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -29,7 +29,8 @@ var ImageHandler = function (format, req) {
   var self = this
 
   this.req = req
-  this.factory = Object.create(StorageFactory)
+  this.storageFactory = Object.create(StorageFactory)
+  this.storageHandler = null
   this.cache = Cache()
 
   var parsedUrl = url.parse(this.req.url, true)
@@ -91,9 +92,9 @@ ImageHandler.prototype.get = function () {
       }
 
       // not in cache, get image from source
-      var storage = self.factory.create('image', self.url)
+      self.storageHandler = self.storageFactory.create('image', self.url)
 
-      storage.get().then(function (stream) {
+      self.storageHandler.get().then(function (stream) {
         var cacheStream = new PassThrough()
         var convertStream = new PassThrough()
         var imageSizeStream = new PassThrough()
@@ -518,6 +519,16 @@ ImageHandler.prototype.contentType = function () {
     default:
       return 'image/jpeg'
   }
+}
+
+ImageHandler.prototype.getFilename = function () {
+  return this.fileName
+}
+
+ImageHandler.prototype.getLastModified = function () {
+  if (!this.storageHandler || !this.storageHandler.getLastModified) return null
+
+  return this.storageHandler.getLastModified()
 }
 
 module.exports = function (format, req) {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -50,20 +50,7 @@ module.exports.sendBackJSONP = function (callbackName, results, res) {
 }
 
 /**
- * Display Error Page
- * status: status code
- * errorMessage: Error Message to display in the error page.
- */
-module.exports.displayErrorPage = function (status, errorMessage, res) {
-  res.statusCode = status || 500
-  res.setHeader('Content-Type', 'text/html')
-  res.write('<h1>Server Error</h1>')
-  res.write('<pre>' + errorMessage + '</pre>')
-  res.end()
-}
-
-/**
- * Display Unauthorization Error Page
+ * Display Unauthorized Error
  */
 module.exports.displayUnauthorizedError = function (res) {
   res.statusCode = 401

--- a/dadi/lib/storage/disk.js
+++ b/dadi/lib/storage/disk.js
@@ -11,10 +11,14 @@ var DiskStorage = function (settings, url) {
 
   this.url = nodeUrl.parse(url, true).pathname
   this.path = path.resolve(settings.directory.path)
+}
 
-  this.getFullUrl = function () {
-    return path.join(self.path, self.url.replace('disk', ''))
-  }
+DiskStorage.prototype.getFullUrl = function () {
+  return path.join(this.path, this.url.replace('disk', ''))
+}
+
+DiskStorage.prototype.getLastModified = function () {
+  return this.lastModified
 }
 
 DiskStorage.prototype.get = function () {
@@ -28,6 +32,8 @@ DiskStorage.prototype.get = function () {
       // check file size
       var stats = fs.statSync(self.getFullUrl())
       var fileSize = parseInt(stats.size)
+
+      self.lastModified = stats.mtime
 
       if (fileSize === 0) {
         var err = {

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -14,10 +14,10 @@ var HTTPStorage = function (settings, url) {
 
   this.url = url
   this.baseUrl = settings.remote.path
+}
 
-  this.getFullUrl = function () {
-    return urljoin(self.baseUrl, self.url.replace('/http/', ''))
-  }
+HTTPStorage.prototype.getFullUrl = function () {
+  return urljoin(this.baseUrl, this.url.replace('/http/', ''))
 }
 
 HTTPStorage.prototype.get = function () {

--- a/dadi/lib/storage/s3.js
+++ b/dadi/lib/storage/s3.js
@@ -22,7 +22,7 @@ var S3Storage = function (settings, url) {
   this.getBucket = function () {
     if (self.url.indexOf('s3') > 0) {
       return _.compact(self.urlParts())[0]
-    }else {
+    } else {
       return settings.s3.bucketName
     }
   }
@@ -35,7 +35,7 @@ var S3Storage = function (settings, url) {
     }
     else if (self.url.substring(1) === '/') {
       return self.url.substring(1)
-    }else {
+    } else {
       return self.url
     }
   }
@@ -47,10 +47,18 @@ var S3Storage = function (settings, url) {
     }
     else if (self.url.substring(1) === '/') {
       return self.url.substring(1).split('/')
-    }else {
+    } else {
       return self.url.split('/')
     }
   }
+}
+
+S3Storage.prototype.getFullUrl = function () {
+  return self.url.replace('/s3', '')
+}
+
+S3Storage.prototype.getLastModified = function () {
+  return this.lastModified
 }
 
 S3Storage.prototype.get = function () {
@@ -79,6 +87,11 @@ S3Storage.prototype.get = function () {
 
     promise.then(
       function (data) {
+
+        if (data.LastModified) {
+          self.lastModified = data.LastModified
+        }
+
         var bufferStream = new stream.PassThrough()
         bufferStream.push(data.Body)
         bufferStream.push(null)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "posttest": "./scripts/coverage.js"
   },
   "dependencies": {
-    "@dadi/status": "git+https://git@github.com/dadi/status.git",
     "@dadi/logger": "latest",
+    "@dadi/status": "git+https://git@github.com/dadi/status.git",
     "aspect-fill": "^1.0.1",
     "aspect-fit": "^1.0.2",
     "async": "^1.4.2",
@@ -24,6 +24,7 @@
     "concat-stream": "^1.5.1",
     "console-stamp": "^0.2.2",
     "convict": "^1.0.1",
+    "etag": "^1.7.0",
     "exif": "^0.6.0",
     "exif2": "0.0.1",
     "finalhandler": "~0.4.0",
@@ -31,6 +32,7 @@
     "imagesize": "~1.0.0",
     "length-stream": "~0.1.1",
     "lwip": "git+https://github.com/Pajk/lwip.git",
+    "mime": "^1.3.4",
     "node-minify": "1.3.2",
     "node-persist": "~0.0.8",
     "node-uuid": "~1.4.7",

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -37,6 +37,17 @@ describe('Controller', function () {
     app.stop(done)
   })
 
+  it('should respond to the root', function (done) {
+    var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+    client
+      .get('/')
+      .end(function(err, res) {
+        res.statusCode.should.eql(200)
+        res.text.should.eql('Welcome to DADI CDN')
+        done()
+      })
+  })
+
   describe('Options Discovery', function (done) {
     it('should extract options from url path if no querystring', function (done) {
       // spy on the sanitiseOptions method to access the provided arguments

--- a/test/unit/cache.js
+++ b/test/unit/cache.js
@@ -108,4 +108,72 @@ describe('Cache', function (done) {
 
     done()
   })
+
+  it("should fallback to directory caching when Redis errors with CONNECTION_BROKEN", function (done) {
+    var newTestConfig = JSON.parse(testConfigString)
+    newTestConfig.caching.directory.enabled = false
+    newTestConfig.caching.redis.enabled = true
+    newTestConfig.caching.redis.host = '127.0.0.1'
+    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+
+    config.loadFile(config.configPath())
+
+    cache.reset()
+
+    // stub calls the redis createClient
+    sinon.stub(redis, 'createClient', fakeredis.createClient)
+
+    var req = {
+      url: '/jpg/50/0/0/801/478/0/0/0/2/aspectfit/North/0/0/0/0/0/test.jpg'
+    }
+
+    var im = new imageHandler('jpg', req)
+
+    redis.createClient.restore()
+
+    config.get('caching.directory.enabled').should.eql(false)
+    config.get('caching.redis.enabled').should.eql(true)
+
+    cache().redisClient.should.exist
+    cache().redisClient.emit('error', { code: 'CONNECTION_BROKEN' })
+
+    config.get('caching.directory.enabled').should.eql(true)
+    config.get('caching.redis.enabled').should.eql(false)
+
+    done()
+  })
+
+  it("should fallback to directory caching when Redis errors with ECONNREFUSED", function (done) {
+    var newTestConfig = JSON.parse(testConfigString)
+    newTestConfig.caching.directory.enabled = false
+    newTestConfig.caching.redis.enabled = true
+    newTestConfig.caching.redis.host = '127.0.0.1'
+    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+
+    config.loadFile(config.configPath())
+
+    cache.reset()
+
+    // stub calls the redis createClient
+    sinon.stub(redis, 'createClient', fakeredis.createClient)
+
+    var req = {
+      url: '/jpg/50/0/0/801/478/0/0/0/2/aspectfit/North/0/0/0/0/0/test.jpg'
+    }
+
+    var im = new imageHandler('jpg', req)
+
+    redis.createClient.restore()
+
+    config.get('caching.directory.enabled').should.eql(false)
+    config.get('caching.redis.enabled').should.eql(true)
+
+    cache().redisClient.should.exist
+    cache().redisClient.emit('error', { code: 'ECONNREFUSED' })
+
+    config.get('caching.directory.enabled').should.eql(true)
+    config.get('caching.redis.enabled').should.eql(false)
+
+    done()
+  })
 })

--- a/test/unit/storage.s3.js
+++ b/test/unit/storage.s3.js
@@ -172,7 +172,7 @@ describe('Storage', function (done) {
       var im = new imageHandler('jpg', req)
 
       // create the s3 handler
-      var storage = im.factory.create('image', req.url)
+      var storage = im.storageFactory.create('image', req.url)
 
       return storage.get().then(function (stream) {
       })


### PR DESCRIPTION
This PR adds cache-control headers, configurable by path or mimetype.

**Note:** Please remove the existing `clientCache` and `gzip` properties from your configuration, they are no longer used.

The above properties have been replaced by the `headers` property below. Add the following to your configuration and adjust as necessary:

```
  headers: {
    useGzipCompression: true,
    cacheControl: {
      "default": "public, max-age=3600",
      "paths": [
        {"path/to/asset.css": "public, max-age=10800"}
      ],
      "mimetypes": [
        {"text/css": "public, max-age=86400"},
        {"text/javascript": "public, max-age=86400"},
        {"application/javascript": "public, max-age=86400"}
      ]
    }
  }
```

The rules are processed in the order of `paths`, `mimetypes` and finally `default` if nothing has matched the request so far.


