### PR TITLE
Check path against loaded workspace files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "istanbul-cobertura-badger": "^1.2.1",
     "mocha": "^3.2.0",
     "proxyquire": "~1.7.4",
+    "redis": "^2.6.3",
     "should": "~11.1.0",
     "sinon": "~1.17.5",
     "standard": "*",

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -310,6 +310,23 @@ describe('Controller', function () {
         })
     })
 
+    it('should handle deep nested test image if image uri using new URL format', function (done) {
+      var newTestConfig = JSON.parse(testConfigString)
+      newTestConfig.images.directory.enabled = true
+      newTestConfig.images.directory.path = './test/images'
+      fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+
+      config.loadFile(config.configPath())
+
+      var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+      client
+        .get('/next-level/test.jpg')
+        .end(function(err, res) {
+          res.statusCode.should.eql(200)
+          done()
+        })
+    })
+
     it('should handle test image if image uri using legacyURLFormat with missing params', function (done) {
       var newTestConfig = JSON.parse(testConfigString)
       newTestConfig.images.directory.enabled = true
@@ -459,6 +476,12 @@ describe('Controller', function () {
         .get('/jpg/50/0/0/801/478/0/0/0/2/aspectfit/North/0/0/0/0/0/testxxx.jpg')
         .end(function(err, res) {
           res.statusCode.should.eql(410)
+
+          newTestConfig.notFound.statusCode = 404
+          newTestConfig.notFound.images.enabled = false
+          fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+          config.loadFile(config.configPath())
+
           done()
         })
     })

--- a/test/acceptance/recipes.js
+++ b/test/acceptance/recipes.js
@@ -265,7 +265,6 @@ describe('Recipes', function () {
     })
 
     it('should return error if the recipe is not found', function (done) {
-
       help.getBearerToken(function (err, token) {
         var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
@@ -355,8 +354,8 @@ describe('Recipes', function () {
           .end(function(err ,res) {
 
             factory.HandlerFactory.prototype.createFromFormat.restore()
-            spy.firstCall.args[0].should.eql('thumbnail')
-            spy.secondCall.args[0].should.eql('jpg')
+            spy.firstCall.args[0].should.eql('jpg')
+            //spy.secondCall.args[0].should.eql('jpg')
 
             // Change the format within the recipe
             var recipeContent = fs.readFileSync(path.join(path.resolve(config.get('paths.recipes')), 'thumbnail.json'))
@@ -373,8 +372,8 @@ describe('Recipes', function () {
               .end(function(err ,res) {
 
                 factory.HandlerFactory.prototype.createFromFormat.restore()
-                spy.firstCall.args[0].should.eql('thumbnail')
-                spy.secondCall.args[0].should.eql('png')
+                spy.firstCall.args[0].should.eql('png')
+                //spy.secondCall.args[0].should.eql('png')
 
                 done()
               })


### PR DESCRIPTION
Checks the first part of the path against an array of loaded workspace files (recipes, routes, etc), then picks a handler accordingly.

Fix #184