### PR TITLE
Fix issue with black line in aspectfill mode

### DIFF
--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -304,6 +304,7 @@ ImageHandler.prototype.convert = function (stream, imageInfo) {
                 */
                 case 'aspectfit':
                   var size = fit(imageInfo.width, imageInfo.height, width, height)
+
                   batch.cover(parseInt(size.width), parseInt(size.height), filter)
                   break
                 /*
@@ -316,13 +317,17 @@ ImageHandler.prototype.convert = function (stream, imageInfo) {
                   var scale = Math.max(scaleWidth, scaleHeight)
                   var crops = self.getCropOffsetsByGravity(options.gravity, imageInfo, dimensions, scale)
 
-                  batch.scale(scale)
+                  if (scaleHeight >= scaleWidth) {
+                    batch.resize(scale * imageInfo.width, height)
+                  } else {
+                    batch.resize(width, scale * imageInfo.height)
+                  }
 
                   // Only crop if the aspect ratio is not the same
                   // if ((width / height) !== (imageInfo.width / imageInfo.height) && !self.storageHandler.notFound) {
                   //   batch.crop(crops.x1, crops.y1, crops.x2, crops.y2)
                   // }
-                  if ((width / height) !== (imageInfo.width / imageInfo.height)) {
+                  if (scaleWidth !== scaleHeight) {
                     batch.crop(crops.x1, crops.y1, crops.x2, crops.y2)
                   }
 


### PR DESCRIPTION
This PR fixes an issue where a black line is added to certain combinations of original size, aspect ratio and request size in the aspectfill resize mode.

To resize the image, we were dividing the desired size by the original size to get a scale factor, which we'd then feed into lwip's `scale()`. We were losing floating point precision in the process, which in certain cases was causing the size of the output image to be off by one pixel.

I replaced `scale()` with `resize()`, supplying the dominant dimension from the desired size directly to the function.