### PR TITLE
fix: ensure uploaded files have safe filenames

### DIFF
--- a/dadi/lib/controller/post.js
+++ b/dadi/lib/controller/post.js
@@ -24,7 +24,6 @@ PostController.prototype.post = (req, res) => {
 
   // Listen for event when Busboy finds a file to stream
   busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
-
     this.fileName = filename.replace(/[^a-z0-9\-_.]+/gi, '_')
     this.mimetype = mimetype
 

--- a/dadi/lib/controller/post.js
+++ b/dadi/lib/controller/post.js
@@ -24,7 +24,8 @@ PostController.prototype.post = (req, res) => {
 
   // Listen for event when Busboy finds a file to stream
   busboy.on('file', (fieldname, file, filename, encoding, mimetype) => {
-    this.fileName = filename
+
+    this.fileName = filename.replace(/[^a-z0-9\-_.]+/gi, '_')
     this.mimetype = mimetype
 
     file.on('data', (chunk) => {


### PR DESCRIPTION
Filenames will now be restricted to alphanumeric with hyphens, underscores and periods.

```js
this.fileName = filename.replace(/[^a-z0-9\-_.]+/gi, '_')
```

Addresses https://github.com/dadi/cdn/issues/197