### PR TITLE
Remove console.log() for cache miss

### DIFF
--- a/dadi/lib/cache/index.js
+++ b/dadi/lib/cache/index.js
@@ -78,7 +78,11 @@ Cache.prototype.getStream = function (key, cb) {
   cache.get(encryptedKey).then((stream) => {
     return cb(stream)
   }).catch((err) => {
-    // key doesn't exist
+    // Key doesn't exist. This silly line only exists because StandardJS
+    // will complain that `err` isn't being handled otherwise.
+    // It's fine, really. This is not really an error.
+    (() => {})(err)
+
     return cb(null)
   })
 }

--- a/dadi/lib/cache/index.js
+++ b/dadi/lib/cache/index.js
@@ -79,7 +79,6 @@ Cache.prototype.getStream = function (key, cb) {
     return cb(stream)
   }).catch((err) => {
     // key doesn't exist
-    console.log(err)
     return cb(null)
   })
 }


### PR DESCRIPTION
I think it's a bit misleading to log an error every time an uncached image is served. This PR removes that log, but by all means ignore it if the log is there for a reason! 😇 

EDIT: I now see that StandardJS is the reason it was there in the first place. It sucks that we can't tell it to ignore a particular line, but this should now keep the linter happy and the log quiet.