### PR TITLE
Add allowFullURL configuration parameter and env variables

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,7 +13,8 @@ var conf = convict({
     port: {
       doc: 'The port number the application will bind to',
       format: 'port',
-      default: 8080
+      default: 8080,
+      env: 'PORT'
     },
     redirectPort: {
       doc: 'Port to redirect http connections to https from',
@@ -190,6 +191,11 @@ var conf = convict({
         doc: 'The remote host to request images from, for example http://media.example.com',
         format: String,
         default: ''
+      },
+      allowFullURL: {
+        doc: 'If true, images can be loaded from any remote URL',
+        format: Boolean,
+        default: false
       }
     }
   },
@@ -295,7 +301,7 @@ var conf = convict({
     }
   },
   status: {
-  	enabled: {
+    enabled: {
       doc: "If true, status endpoint is enabled.",
       format: Boolean,
       default: true

--- a/config.js
+++ b/config.js
@@ -266,7 +266,8 @@ var conf = convict({
       enabled: {
         doc: 'If true, cache files will be saved to the filesystem',
         format: Boolean,
-        default: true
+        default: true,
+        env: 'CACHE_ENABLE_DIRECTORY'
       },
       path: {
         doc: 'The relative path to the cache directory',
@@ -278,7 +279,8 @@ var conf = convict({
       enabled: {
         doc: 'If true, cache files will be saved to the specified Redis server',
         format: Boolean,
-        default: false
+        default: false,
+        env: 'CACHE_ENABLE_REDIS'
       },
       host: {
         doc: 'The Redis server host',

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -171,6 +171,15 @@ ImageHandler.prototype.get = function () {
 
       // not in cache, get image from source
       if (this.externalUrl) {
+        if (!config.get('images.remote.enabled') || !config.get('images.remote.allowFullURL')) {
+          const err = {
+            statusCode: 403,
+            message: 'Loading images from a full remote URL is not supported by this instance of DADI CDN'
+          }
+
+          return reject(err)
+        }
+
         this.storageHandler = new HTTPStorage(null, this.externalUrl)
       } else {
         this.storageHandler = this.storageFactory.create('image', this.url)

--- a/test/unit/storage.http.js
+++ b/test/unit/storage.http.js
@@ -52,11 +52,34 @@ describe('Storage', function (done) {
       httpStorage.getFullUrl().should.eql('https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png')
     })
 
-    it('should make a request for the specified external URL', function () {
+    it('should block a request for the specified external URL if allowFullURL is false', function () {
       var newTestConfig = JSON.parse(testConfigString)
       newTestConfig.images.directory.enabled = false
       newTestConfig.images.s3.enabled = false
       newTestConfig.images.remote.enabled = true
+      newTestConfig.images.remote.allowFullURL = false
+      fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+
+      config.loadFile(config.configPath())
+
+      var req = {
+        url: '/https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png'
+      }
+
+      var im = new imageHandler('png', req)
+      return im.get().catch(function (err) {
+        err.statusCode.should.eql(403)
+
+        return Promise.resolve(true)
+      })
+    })
+
+    it('should make a request for the specified external URL if allowFullURL is true', function () {
+      var newTestConfig = JSON.parse(testConfigString)
+      newTestConfig.images.directory.enabled = false
+      newTestConfig.images.s3.enabled = false
+      newTestConfig.images.remote.enabled = true
+      newTestConfig.images.remote.allowFullURL = true
       fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
 
       config.loadFile(config.configPath())


### PR DESCRIPTION
This PR adds a new configuration parameter (`images.remote.allowFullURL`) which toggles the use of remote images from a full URL (e.g. `https://cdn.com/https://another-full-url.com/image.jpg`). Allowing images to be loaded from anywhere means that people can, in theory, use my instance of CDN to load, manipulate and deliver their images on their site, so I think it should be something I actively choose to enable.

Unrelated to that, it also introduces three additional environment variables:

- `PORT`: specifies the server port
- `CACHE_ENABLE_DIRECTORY`: toggles directory-based caching
- `CACHE_ENABLE_REDIS`: toggles Redis caching