### PR TITLE
Ensure remote urls keep querystring

### DIFF
--- a/config.js
+++ b/config.js
@@ -195,7 +195,7 @@ var conf = convict({
       allowFullURL: {
         doc: 'If true, images can be loaded from any remote URL',
         format: Boolean,
-        default: false
+        default: true
       }
     }
   },

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -69,7 +69,7 @@ var ImageHandler = function (format, req) {
   this.exifData = {}
 
   if (!pathname.indexOf('http://') || !pathname.indexOf('https://')) {
-    this.externalUrl = pathname
+    this.externalUrl = parsedUrl.path.slice(1)
   }
 }
 
@@ -807,6 +807,16 @@ ImageHandler.prototype.sanitiseOptions = function (options) {
   ]
 
   var imageOptions = {}
+
+  // handle querystring options that came from a remote image url
+  // as if the original remote url had it's own querystring then we'll
+  // get an option here that starts with a ?, from where the CDN params were added
+  _.each(Object.keys(options), function (key) {
+    if (key[0] === '?') {
+      options[key.substring(1)] = options[key]
+      delete options[key]
+    }
+  })
 
   _.each(Object.keys(options), function (key) {
     var settings = _.filter(optionSettings, function (setting) {

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -1,5 +1,7 @@
+var _ = require('underscore')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
+var nodeUrl = require('url')
 var path = require('path')
 var sha1 = require('sha1')
 // var stream = require('stream')
@@ -20,7 +22,21 @@ mkdirp(tmpDirectory, (err, made) => {
 var HTTPStorage = function (settings, url) {
   if (settings && !settings.remote.path) throw new Error('Remote address not specified')
 
-  this.url = url
+  this.query = ''
+
+  if (!url.indexOf('http://') || !url.indexOf('https://')) {
+    var parsedUrl = nodeUrl.parse(url, true)
+    this.url = parsedUrl.protocol + '//' + parsedUrl.host + parsedUrl.pathname
+
+    var querystring = parsedUrl.search
+    var query = _.compact(querystring.split('?'))[0]
+
+    if (query && query !== 'version=2') {
+      this.query = '?' + query
+    }
+  } else {
+    this.url = url
+  }
 
   if (settings) {
     this.baseUrl = settings.remote.path
@@ -29,9 +45,9 @@ var HTTPStorage = function (settings, url) {
 
 HTTPStorage.prototype.getFullUrl = function () {
   if (this.baseUrl) {
-    return urljoin(this.baseUrl, this.url.replace('/http/', ''))
+    return urljoin(this.baseUrl, this.url.replace('/http/', '')) + this.query
   } else {
-    return this.url
+    return this.url + this.query
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/cdn",
-  "version": "0.0.0-development",
+  "version": "1.10.3",
   "description": "A high performance, just-in-time asset manipulation and delivery layer designed as a modern content distribution solution.",
   "scripts": {
     "init": "validate-commit-msg",

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -216,6 +216,26 @@ describe('Controller', function () {
           done()
         })
     })
+
+    it('v2: should extract options from querystring if an external URL with URL params is provided', function (done) {
+      // spy on the sanitiseOptions method to access the provided arguments
+      var method = sinon.spy(imageHandler.ImageHandler.prototype, 'sanitiseOptions')
+
+      var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+      client
+        .get('/https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?h=32&?quality=50&width=80&height=478&gravity=North&resizeStyle=aspectfit&devicePixelRatio=2')
+        .end(function (err, res) {
+          imageHandler.ImageHandler.prototype.sanitiseOptions.restore()
+
+          method.called.should.eql(true)
+          var options = method.returnValues[0]
+
+          options.quality.should.eql(50)
+          options.width.should.eql(80)
+          options.format.should.eql('png')
+          done()
+        })
+    })
   })
 
   describe('Assets', function () {

--- a/test/unit/storage.http.js
+++ b/test/unit/storage.http.js
@@ -52,6 +52,24 @@ describe('Storage', function (done) {
       httpStorage.getFullUrl().should.eql('https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png')
     })
 
+    it('should use specified URL with URL parameters when passing external URL in request', function () {
+      var newTestConfig = JSON.parse(testConfigString)
+      newTestConfig.images.directory.enabled = false
+      newTestConfig.images.s3.enabled = false
+      newTestConfig.images.remote.enabled = true
+      fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+
+      config.loadFile(config.configPath())
+
+      var req = {
+        url: '/https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?h=32'
+      }
+
+      var httpStorage = new HTTPStorage(null, req.url.substring(1))
+
+      httpStorage.getFullUrl().should.eql('https://www.google.co.uk/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?h=32')
+    })
+
     it('should block a request for the specified external URL if allowFullURL is false', function () {
       var newTestConfig = JSON.parse(testConfigString)
       newTestConfig.images.directory.enabled = false


### PR DESCRIPTION
This PR adds support for remote URLs that already have a querystring, ensuring that it is passed through in full to the request.

Close #223 