### PR TITLE
feat: add more intuitive cropping behaviour

### DIFF
--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -409,13 +409,13 @@ ImageHandler.prototype.convert = function (stream, imageInfo) {
             */
             case 'crop':
               if (options.crop) {
-                var coords = options.crop.split(',').map(coord => parseInt(coord))
+                let coords = options.crop.split(',').map(coord => parseInt(coord))
                 if (coords.length === 2) {
                   coords.push(height - coords[0])
                   coords.push(width - coords[1])
                 }
 
-                var cropDimensions = {
+                const cropDimensions = {
                   left: coords[1],
                   top: coords[0],
                   width: coords[3] - coords[1],
@@ -445,8 +445,8 @@ ImageHandler.prototype.convert = function (stream, imageInfo) {
                 }
               } else {
                 // Width & height provided, crop from centre
-                var excessWidth = Math.max(0, imageInfo.width - width)
-                var excessHeight = Math.max(0, imageInfo.height - height)
+                const excessWidth = Math.max(0, imageInfo.width - width)
+                const excessHeight = Math.max(0, imageInfo.height - height)
 
                 sharpImage.extract({
                   left: Math.round(excessWidth / 2),

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -410,22 +410,38 @@ ImageHandler.prototype.convert = function (stream, imageInfo) {
             case 'crop':
               if (options.crop) {
                 var coords = options.crop.split(',').map(coord => parseInt(coord))
-
                 if (coords.length === 2) {
                   coords.push(height - coords[0])
                   coords.push(width - coords[1])
                 }
 
-                sharpImage.extract({
+                var cropDimensions = {
                   left: coords[1],
                   top: coords[0],
                   width: coords[3] - coords[1],
                   height: coords[2] - coords[0]
-                })
+                }
+                sharpImage.extract(cropDimensions)
 
                 // resize if options.width or options.height are explicitly set
                 if (options.width || options.height) {
-                  sharpImage.resize(options.width, options.height, resizeOptions)
+                  if (options.width && options.height) {
+                    sharpImage = sharpImage.ignoreAspectRatio()
+                  }
+
+                  if (options.devicePixelRatio && options.devicePixelRatio < 4) {
+                    let adjustedWidth = parseFloat(options.width) * parseFloat(options.devicePixelRatio)
+                    let adjustedHeight = parseFloat(options.height) * parseFloat(options.devicePixelRatio)
+                    sharpImage.resize(adjustedWidth || undefined, adjustedHeight || undefined, resizeOptions)
+                  } else {
+                    sharpImage.resize(options.width, options.height, resizeOptions)
+                  }
+                } else {
+                  if (options.devicePixelRatio && options.devicePixelRatio < 4) {
+                    let adjustedWidth = parseFloat(cropDimensions.width) * parseFloat(options.devicePixelRatio)
+                    let adjustedHeight = parseFloat(cropDimensions.height) * parseFloat(options.devicePixelRatio)
+                    sharpImage.resize(adjustedWidth || undefined, adjustedHeight || undefined, resizeOptions)
+                  }
                 }
               } else {
                 // Width & height provided, crop from centre


### PR DESCRIPTION
Fixes #270

Cropping, as it stands, does not always act intuitively. These changes should make it act a bit more like you would expect given a set of URLs. DevicePixelRatio is now respected, along with distorting images by providing both width & height. These changes only affect resize style `crop`.

See below for explanations (lifted from issue comments.)