### PR TITLE
fix: retain aspect ratio on maxWidth/maxHeight resize

### DIFF
--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -811,11 +811,15 @@ function getDimensions (options, imageInfo) {
   }
 
   if (config.get('security.maxWidth') && config.get('security.maxWidth') < dimensions.width) {
+    const hwr = parseFloat(dimensions.height / dimensions.width)
     dimensions.width = config.get('security.maxWidth')
+    dimensions.height = dimensions.width * hwr
   }
 
   if (config.get('security.maxHeight') && config.get('security.maxHeight') < dimensions.height) {
+    const whr = parseFloat(dimensions.width / dimensions.height)
     dimensions.height = config.get('security.maxHeight')
+    dimensions.width = dimensions.height * whr
   }
 
   if (options.devicePixelRatio && options.devicePixelRatio < 4) {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -23,6 +23,9 @@ module.exports.sendBackJSON = function (successCode, results, res) {
   res.statusCode = successCode
 
   var resBody = JSON.stringify(results)
+  if (results instanceof Error && resBody === '{}') {
+    resBody = JSON.stringify({ message: results.message || 'unknown error' })
+  }
 
   res.setHeader('Server', config.get('server.name'))
   res.setHeader('Content-Type', 'application/json')

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -583,7 +583,7 @@ describe('Controller', function () {
 
       var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
       client
-        .get('/test.jpg?width=2000&cropX=20&cropY=20')
+        .get('/test.jpg?resize=crop&crop=0,0,3000,3000')
         .end(function(err, res) {
           res.statusCode.should.eql(400)
           res.body.message.should.exist


### PR DESCRIPTION
CDN allows the configuration of the `maxWidth` and `maxHeight` variables which are used to ensure that any image assets that exceed these dimensions are resized before being served. Recently, an [innocent change](https://github.com/dadi/somedomain.tech/commit/16eb5d6c9d923d6c9b24cc9b8fed3fb189da2649) to the somdomain.tech CDN service highlighted an issue where the aspect ratio was not respected when these resizes were being made.

This PR addresses this issue, and resizes both the height and width for each dimension.

For example, if an image is `4000 x 3000` pixels and `maxWidth` is set to `800`, when the image is resized from `4000` wide to `800` wide, it will also have it's height scaled by the same ratio, to `600` in this case:

![image](https://user-images.githubusercontent.com/1639527/31940790-49da947a-b8b7-11e7-85f0-3510d8b6c73f.png)

The above image was originally `4000 x 3000` pixels with a `50` pixel border to highlight the image boundary. Now you can see it is `800 x 600` and the boundary is intact.

In the case where the resized height still exceeds the `maxHeight` value, the width will this time be scaled as to adequately retain the aspect ratio. For example, let's take the above `4000 x 3000` image, and set `maxWidth` to `800`, but we'll set `maxHeight` to `400`:

![image](https://user-images.githubusercontent.com/1639527/31940860-9c9fb0e6-b8b7-11e7-9663-96254cd7115b.png)

In this case, the image is first resized from `4000 x 3000` to `800 x 600`, and then again resized to `533 x 400`. This two-pass technique allows us to retain the aspect ratio while ensuring no dimension limit is exceeded.