### PR TITLE
Fix: default image sharpness

### DIFF
--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -872,7 +872,7 @@ ImageHandler.prototype.optionSettings = function () {
   return [
     { name: 'format', aliases: ['fmt'] },
     { name: 'quality', aliases: ['q'], default: 75 },
-    { name: 'sharpen', aliases: ['sh'], default: 1, allowZero: true },
+    { name: 'sharpen', aliases: ['sh'], default: 0, allowZero: true },
     { name: 'saturate', aliases: ['sat'], default: 1, allowZero: true },
     { name: 'width', aliases: ['w'] },
     { name: 'height', aliases: ['h'] },

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -872,7 +872,7 @@ ImageHandler.prototype.optionSettings = function () {
   return [
     { name: 'format', aliases: ['fmt'] },
     { name: 'quality', aliases: ['q'], default: 75 },
-    { name: 'sharpen', aliases: ['sh'], default: 1 },
+    { name: 'sharpen', aliases: ['sh'], default: 1, allowZero: true },
     { name: 'saturate', aliases: ['sat'], default: 1, allowZero: true },
     { name: 'width', aliases: ['w'] },
     { name: 'height', aliases: ['h'] },

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -921,8 +921,11 @@ ImageHandler.prototype.sanitiseOptions = function (options) {
         if (options[key] !== '0' || settings[0].allowZero) {
           if (settings[0].lowercase) value = value.toLowerCase()
           value = _.isFinite(value) ? parseFloat(value) : value
-          if (settings[0].minimumValue && value < settings[0].minimumValue) value = settings[0].minimumValue
-          else if (settings[0].maximumValue && value > settings[0].maximumValue) value = settings[0].maximumValue
+          if (settings[0].minimumValue && value < settings[0].minimumValue) {
+            value = settings[0].minimumValue
+          } else if (settings[0].maximumValue && value > settings[0].maximumValue) {
+            value = settings[0].maximumValue
+          }
           imageOptions[settings[0].name] = value
         } else {
           imageOptions[settings[0].name] = settings[0].default

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -920,7 +920,10 @@ ImageHandler.prototype.sanitiseOptions = function (options) {
       if (options[key] !== '0' || settings[0].allowZero || settings[0].default) {
         if (options[key] !== '0' || settings[0].allowZero) {
           if (settings[0].lowercase) value = value.toLowerCase()
-          imageOptions[settings[0].name] = _.isFinite(value) ? parseFloat(value) : value
+          value = _.isFinite(value) ? parseFloat(value) : value
+          if (settings[0].minimumValue && value < settings[0].minimumValue) value = settings[0].minimumValue
+          else if (settings[0].maximumValue && value > settings[0].maximumValue) value = settings[0].maximumValue
+          imageOptions[settings[0].name] = value
         } else {
           imageOptions[settings[0].name] = settings[0].default
         }

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -872,7 +872,7 @@ ImageHandler.prototype.optionSettings = function () {
   return [
     { name: 'format', aliases: ['fmt'] },
     { name: 'quality', aliases: ['q'], default: 75 },
-    { name: 'sharpen', aliases: ['sh'], default: 0, allowZero: true },
+    { name: 'sharpen', aliases: ['sh'], default: 0, allowZero: true, minimumValue: 1 },
     { name: 'saturate', aliases: ['sat'], default: 1, allowZero: true },
     { name: 'width', aliases: ['w'] },
     { name: 'height', aliases: ['h'] },


### PR DESCRIPTION
Fixes #276 

000498f fix: allow zero as sharpness param value
b2ffe24 fix: do not sharpen images by default

Old default:
![image](https://user-images.githubusercontent.com/1639527/32287551-1f3f935a-bf29-11e7-8e31-7470e43beb5e.png)

New default:
![image](https://user-images.githubusercontent.com/1639527/32287536-18793788-bf29-11e7-8a05-af4cdc03ddee.png)

Adding `sharpen=0` (same as default):
![image](https://user-images.githubusercontent.com/1639527/32287574-2f20f912-bf29-11e7-8c48-5fb8364ffc71.png)


