### PR TITLE
Use getStream to better handle missing cache file

### DIFF
--- a/dadi/lib/models/route.js
+++ b/dadi/lib/models/route.js
@@ -218,7 +218,7 @@ Route.prototype.getNetwork = function () {
 }
 
 Route.prototype.getRecipe = function () {
-  return cache.get(this._getCacheKey()).then((cachedRecipe) => {
+  return cache.getStream(this._getCacheKey()).then(cachedRecipe => {
     if (cachedRecipe) return Promise.resolve(cachedRecipe)
 
     return this.processRoute().then((recipe) => {
@@ -226,7 +226,6 @@ Route.prototype.getRecipe = function () {
         return cache.set(this._getCacheKey(), recipe).then(() => {
           return recipe
         }).catch((err) => {
-          console.log(err)
           return recipe
         })
       }

--- a/dadi/lib/models/route.js
+++ b/dadi/lib/models/route.js
@@ -219,7 +219,7 @@ Route.prototype.getNetwork = function () {
 
 Route.prototype.getRecipe = function () {
   return cache.getStream(this._getCacheKey()).then(cachedRecipe => {
-    if (cachedRecipe) return Promise.resolve(cachedRecipe)
+    if (cachedRecipe) return cachedRecipe
 
     return this.processRoute().then((recipe) => {
       if (recipe) {

--- a/dadi/lib/models/route.js
+++ b/dadi/lib/models/route.js
@@ -226,6 +226,7 @@ Route.prototype.getRecipe = function () {
         return cache.set(this._getCacheKey(), recipe).then(() => {
           return recipe
         }).catch((err) => {
+          console.log(err)
           return recipe
         })
       }


### PR DESCRIPTION
This PR ensures that if the cache doesn't contain the requested key then it can continue to process the request, rather than returning the cache module's error to the end-user.

Fix #317