### PR TITLE
Flush cache by domain

### DIFF
--- a/config.js
+++ b/config.js
@@ -262,6 +262,12 @@ const schema = {
     }
   },
   caching: {
+    expireAt: {
+      doc: 'Cron-style pattern specifying when the cache should be expired',
+      format: String,
+      default: null,
+      allowDomainOverride: true
+    },
     ttl: {
       doc: '',
       format: Number,

--- a/dadi/lib/cache/index.js
+++ b/dadi/lib/cache/index.js
@@ -51,7 +51,9 @@ Cache.prototype.cacheFile = function (stream, key, wait) {
  * @param  {Function} callback
  */
 Cache.prototype.delete = function (pattern, callback) {
-  cache.flush(pattern).then(() => {
+  let hashedPattern = this.getNormalisedKey(pattern)
+
+  cache.flush(hashedPattern).then(() => {
     return callback(null)
   }).catch((err) => {
     console.log(err)
@@ -69,6 +71,8 @@ Cache.prototype.delete = function (pattern, callback) {
  * @return {String}
  */
 Cache.prototype.getNormalisedKey = function (key) {
+  if (key === '') return key
+
   if (Array.isArray(key)) {
     return key.reduce((normalisedKey, node) => {
       if (node || (node === 0)) {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -8,7 +8,6 @@ const path = require('path')
 const urlParser = require('url')
 const zlib = require('zlib')
 
-const Cache = require(path.join(__dirname, '/../cache'))
 const config = require(path.join(__dirname, '/../../../config'))
 const help = require(path.join(__dirname, '/../help'))
 const logger = require('@dadi/logger')
@@ -104,12 +103,12 @@ const Controller = function (router) {
       }, res)
     }
 
-    let pattern = ''
+    let pattern = [req.__domain]
 
     if (req.body.pattern !== '*') {
       let parsedUrl = urlParser.parse(req.body.pattern, true)
 
-      pattern = Cache().getNormalisedKey([
+      pattern = pattern.concat([
         parsedUrl.pathname,
         parsedUrl.search.slice(1)
       ])

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -278,9 +278,17 @@ Server.prototype.start = function (done) {
   workspace.createDirectories()
   workspace.startWatchingFiles()
 
+  this.startCacheFlushing()
+
   if (typeof done === 'function') {
     done()
   }
+}
+
+Server.prototype.startCacheFlushing = function () {
+  domainManager.getDomains().forEach(({domain, path: domainPath}) => {
+    console.log('---> Domain:', domain, config.get('caching.expireAt', domain))
+  })
 }
 
 /**

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -15,12 +15,18 @@ const dadiStatus = require('@dadi/status')
 const domainManager = require('./models/domain-manager')
 const workspace = require('./models/workspace')
 
-// let's ensure there's at least a dev config file here
-const devConfigPath = path.join(__dirname, '/../../config/config.development.json')
+// Let's ensure there's at least a dev config file here.
+const devConfigPath = path.join(
+  __dirname,
+  '/../../config/config.development.json'
+)
 
 fs.stat(devConfigPath, (err, stats) => {
   if (err && err.code === 'ENOENT') {
-    fs.writeFileSync(devConfigPath, fs.readFileSync(devConfigPath + '.sample'))
+    fs.writeFileSync(
+      devConfigPath,
+      fs.readFileSync(devConfigPath + '.sample')
+    )
   }
 })
 
@@ -29,13 +35,15 @@ const Controller = require(path.join(__dirname, '/controller'))
 const configPath = path.resolve(path.join(__dirname, '/../../config'))
 const config = require(configPath)
 
-function createServer (listener) {
-  var protocol = config.get('server.protocol')
+const Server = function () {}
+
+Server.prototype.create = function (listener) {
+  let protocol = config.get('server.protocol')
 
   if (protocol === 'http') {
     return http.createServer(listener)
   } else if (protocol === 'https') {
-    var readFileSyncSafe = (path) => {
+    let readFileSyncSafe = (path) => {
       try {
         return fs.readFileSync(path)
       } catch (ex) {
@@ -45,10 +53,10 @@ function createServer (listener) {
       return null
     }
 
-    var passphrase = config.get('server.sslPassphrase')
-    var caPath = config.get('server.sslIntermediateCertificatePath')
-    var caPaths = config.get('server.sslIntermediateCertificatePaths')
-    var serverOptions = {
+    let passphrase = config.get('server.sslPassphrase')
+    let caPath = config.get('server.sslIntermediateCertificatePath')
+    let caPaths = config.get('server.sslIntermediateCertificatePaths')
+    let serverOptions = {
       key: readFileSyncSafe(config.get('server.sslPrivateKeyPath')),
       cert: readFileSyncSafe(config.get('server.sslCertificatePath'))
     }
@@ -59,25 +67,31 @@ function createServer (listener) {
 
     if (caPaths && caPaths.length > 0) {
       serverOptions.ca = []
-      caPaths.forEach((path) => {
-        var data = readFileSyncSafe(path)
-        data && serverOptions.ca.push(data)
+      caPaths.forEach(path => {
+        let data = readFileSyncSafe(path)
+
+        if (data) {
+          serverOptions.ca.push(data)
+        }
       })
     } else if (caPath && caPath.length > 0) {
       serverOptions.ca = readFileSyncSafe(caPath)
     }
 
-    // we need to catch any errors resulting from bad parameters
-    // such as incorrect passphrase or no passphrase provided
+    // We need to catch any errors resulting from bad parameters,
+    // such as incorrect passphrase or no passphrase provided.
     try {
       return https.createServer(serverOptions, listener)
     } catch (ex) {
-      var exPrefix = 'error starting https server: '
+      let exPrefix = 'error starting https server: '
+
       switch (ex.message) {
         case 'error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt':
           throw new Error(exPrefix + 'incorrect ssl passphrase')
+
         case 'error:0906A068:PEM routines:PEM_do_header:bad password read':
           throw new Error(exPrefix + 'required ssl passphrase not provided')
+
         default:
           throw new Error(exPrefix + ex.message)
       }
@@ -85,12 +99,12 @@ function createServer (listener) {
   }
 }
 
-function onListening (server) {
-  var env = config.get('env')
-  var address = server.address()
+Server.prototype.onListening = function () {
+  let address = this.address()
+  let env = config.get('env')
 
   if (env !== 'test') {
-    var startText = '\n  ----------------------------\n'
+    let startText = '\n  ----------------------------\n'
     startText += '  Started \'DADI CDN\'\n'
     startText += '  ----------------------------\n'
     startText += '  Server:      '.green + address.address + ':' + address.port + '\n'
@@ -105,12 +119,12 @@ function onListening (server) {
   }
 }
 
-function onRedirectListening (server) {
-  var env = config.get('env')
-  var address = server.address()
+Server.prototype.onRedirectListening = function () {
+  let address = this.address()
+  let env = config.get('env')
 
   if (env !== 'test') {
-    var startText = '\n  ----------------------------\n'
+    let startText = '\n  ----------------------------\n'
     startText += '  Started HTTP -> HTTPS Redirect\n'
     startText += '  ----------------------------\n'
     startText += '  Server:      '.green + address.address + ':' + address.port + '\n'
@@ -120,12 +134,12 @@ function onRedirectListening (server) {
   }
 }
 
-function onStatusListening (server) {
-  var env = config.get('env')
-  var address = server.address()
+Server.prototype.onStatusListening = function () {
+  var address = this.address()
+  let env = config.get('env')
 
   if (env !== 'test') {
-    var startText = '\n  ----------------------------\n'
+    let startText = '\n  ----------------------------\n'
     startText += '  Started standalone status endpoint\n'
     startText += '  ----------------------------\n'
     startText += '  Server:      '.green + address.address + ':' + address.port + '\n'
@@ -134,8 +148,6 @@ function onStatusListening (server) {
     console.log(startText)
   }
 }
-
-var Server = function () {}
 
 Server.prototype.start = function (done) {
   router.use((req, res, next) => {
@@ -155,96 +167,61 @@ Server.prototype.start = function (done) {
     res.end('Welcome to DADI CDN')
   })
 
-  var statusHandler = function (req, res, next) {
-    var method = req.method && req.method.toLowerCase()
-    var authorization = req.headers.authorization
-
-    if (method !== 'post' || config.get('status.enabled') === false) {
-      return next()
-    } else {
-      var params = {
-        site: site,
-        package: '@dadi/cdn',
-        version: version,
-        healthCheck: {
-          authorization: authorization,
-          baseUrl: 'http://' + config.get('server.host') + ':' + config.get('server.port'),
-          routes: config.get('status.routes')
-        }
-      }
-
-      dadiStatus(params, function (err, data) {
-        if (err) return next(err)
-
-        var responseMessages = {
-          Green: 'Service is responding within specified parameters',
-          Amber: 'Service is responding, but outside of specified parameters'
-        }
-
-        data.status = {
-          status: data.routes[0].status,
-          healthStatus: data.routes[0].healthStatus,
-          message: responseMessages[data.routes[0].healthStatus] || 'Service is not responding correctly'
-        }
-
-        var resBody = JSON.stringify(data, null, 2)
-
-        res.statusCode = 200
-        res.setHeader('Content-Type', 'application/json')
-        res.setHeader('Content-Length', Buffer.byteLength(resBody))
-        return res.end(resBody)
-      })
-    }
-  }
-
-  // ensure that middleware runs in the correct order,
-  // especially when running an integrated status page
+  // Ensure that middleware runs in the correct order,
+  // especially when running an integrated status page.
   if (config.get('status.standalone')) {
-    var statusRouter = Router()
-    config.get('status.requireAuthentication') && auth(statusRouter)
-    statusRouter.use('/api/status', statusHandler)
+    let statusRouter = Router()
 
-    var statusApp = http.createServer(function (req, res) {
+    config.get('status.requireAuthentication') && auth(statusRouter)
+    statusRouter.use('/api/status', this.status)
+
+    let statusApp = http.createServer(function (req, res) {
       res.setHeader('Server', config.get('server.name'))
       res.setHeader('Access-Control-Allow-Origin', '*')
       res.setHeader('Cache-Control', 'no-cache')
+
       statusRouter(req, res, finalhandler(req, res))
     })
 
-    var statusServer = this.statusServer = statusApp.listen(config.get('status.port'))
-    statusServer.on('listening', function () { onStatusListening(this) })
+    let statusServer = statusApp.listen(config.get('status.port'))
+
+    statusServer.on('listening', this.onStatusListening)
+
+    this.statusServer = statusServer
 
     auth(router)
   } else {
     if (config.get('status.requireAuthentication')) {
       auth(router)
-      router.use('/api/status', statusHandler)
+      router.use('/api/status', this.status)
     } else {
-      router.use('/api/status', statusHandler)
+      router.use('/api/status', this.status)
       auth(router)
     }
   }
 
   this.controller = new Controller(router)
 
-  var redirectInstance
-  var redirectServer
-  var redirectPort = config.get('server.redirectPort')
+  let redirectInstance
+  let redirectServer
+  let redirectPort = config.get('server.redirectPort')
+
   if (redirectPort > 0) {
     redirectInstance = http.createServer((req, res) => {
-      var port = config.get('server.port')
-      var hostname = req.headers.host.split(':')[0]
-      var location = 'https://' + hostname + ':' + port + req.url
+      let port = config.get('server.port')
+      let hostname = req.headers.host.split(':')[0]
+      let location = `https://${hostname}:${port}${req.url}`
 
       res.setHeader('Location', location)
       res.statusCode = 301
       res.end()
     })
-    redirectServer = this.redirectServer = redirectInstance.listen(redirectPort)
-    redirectServer.on('listening', function () { onRedirectListening(this) })
+
+    redirectServer = redirectInstance.listen(redirectPort)
+    redirectServer.on('listening', this.onRedirectListening)
   }
 
-  let app = createServer((req, res) => {
+  let app = this.create((req, res) => {
     if (config.get('multiDomain.enabled')) {
       let domain = req.headers.host.split(':')[0]
 
@@ -268,10 +245,11 @@ Server.prototype.start = function (done) {
     router(req, res, finalhandler(req, res))
   })
 
-  let server = this.server = app.listen(config.get('server.port'))
-  server.on('listening', function () { onListening(this) })
+  let server = app.listen(config.get('server.port'))
+  server.on('listening', this.onListening)
 
   this.readyState = 1
+  this.server = server
 
   workspace.createDirectories()
   workspace.startWatchingFiles()
@@ -281,24 +259,72 @@ Server.prototype.start = function (done) {
   }
 }
 
-// this is mostly needed for tests
+Server.prototype.status = function (req, res, next) {
+  let method = req.method && req.method.toLowerCase()
+  let authorization = req.headers.authorization
+
+  if (method !== 'post' || config.get('status.enabled') === false) {
+    return next()
+  }
+
+  let params = {
+    site: site,
+    package: '@dadi/cdn',
+    version: version,
+    healthCheck: {
+      authorization: authorization,
+      baseUrl: `http://${config.get('server.host')}:${config.get('server.port')}`,
+      routes: config.get('status.routes')
+    }
+  }
+
+  dadiStatus(params, (err, data) => {
+    if (err) return next(err)
+
+    let responseMessages = {
+      Green: 'Service is responding within specified parameters',
+      Amber: 'Service is responding, but outside of specified parameters'
+    }
+
+    data.status = {
+      status: data.routes[0].status,
+      healthStatus: data.routes[0].healthStatus,
+      message: responseMessages[data.routes[0].healthStatus] ||
+        'Service is not responding correctly'
+    }
+
+    let resBody = JSON.stringify(data, null, 2)
+
+    res.statusCode = 200
+    res.setHeader('Content-Type', 'application/json')
+    res.setHeader('Content-Length', Buffer.byteLength(resBody))
+
+    return res.end(resBody)
+  })
+}
+
+// This is mostly needed for tests.
 Server.prototype.stop = function (done) {
   this.readyState = 3
 
   workspace.stopWatchingFiles()
 
   this.server.close(err => {
-    // if statusServer is running in standalone, close that too
+    // If statusServer is running in standalone, close that too.
     if (this.statusServer) {
       this.statusServer.close(err => {
         this.readyState = 0
 
-        done && done(err)
+        if (typeof done === 'function') {
+          done(err)
+        }
       })
     } else {
       this.readyState = 0
 
-      done && done(err)
+      if (typeof done === 'function') {
+        done(err)
+      }
     }
   })
 }

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -37,6 +37,13 @@ const config = require(configPath)
 
 const Server = function () {}
 
+/**
+ * Creates an HTTP or HTTPS server and calls `listener`
+ * once the server is listening for requests.
+ *
+ * @param  {Function} listener
+ * @return {http.Server}
+ */
 Server.prototype.create = function (listener) {
   let protocol = config.get('server.protocol')
 
@@ -99,6 +106,9 @@ Server.prototype.create = function (listener) {
   }
 }
 
+/**
+ * Handler function for when the server is listening for requests.
+ */
 Server.prototype.onListening = function () {
   let address = this.address()
   let env = config.get('env')
@@ -119,6 +129,10 @@ Server.prototype.onListening = function () {
   }
 }
 
+/**
+ * Handler function for when the HTTP->HTTPS redirect server
+ * is listening for requests.
+ */
 Server.prototype.onRedirectListening = function () {
   let address = this.address()
   let env = config.get('env')
@@ -134,6 +148,10 @@ Server.prototype.onRedirectListening = function () {
   }
 }
 
+/**
+ * Handler function for when the status endpoint server is
+ * listening for requests.
+ */
 Server.prototype.onStatusListening = function () {
   var address = this.address()
   let env = config.get('env')
@@ -149,6 +167,12 @@ Server.prototype.onStatusListening = function () {
   }
 }
 
+/**
+ * Bootstraps the application, initialising the web server and
+ * attaching all the necessary middleware and routing logic.
+ *
+ * @param  {Function} done - callback function
+ */
 Server.prototype.start = function (done) {
   router.use((req, res, next) => {
     const FAVICON_REGEX = /\/(favicon|(apple-)?touch-icon(-i(phone|pad))?(-\d{2,}x\d{2,})?(-precomposed)?)\.(jpe?g|png|ico|gif)$/i
@@ -259,6 +283,13 @@ Server.prototype.start = function (done) {
   }
 }
 
+/**
+ * Responds to requests to the status endpoint.
+ *
+ * @param  {http.ClientRequest}   req
+ * @param  {http.ServerResponse}  res
+ * @param  {Function}             next
+ */
 Server.prototype.status = function (req, res, next) {
   let method = req.method && req.method.toLowerCase()
   let authorization = req.headers.authorization
@@ -303,7 +334,12 @@ Server.prototype.status = function (req, res, next) {
   })
 }
 
-// This is mostly needed for tests.
+/**
+ * Stops all the server instances and terminates the file watcher.
+ * Used mostly for unit tests.
+ *
+ * @param  {Function} done
+ */
 Server.prototype.stop = function (done) {
   this.readyState = 3
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "posttest": "./scripts/coverage.js"
   },
   "dependencies": {
-    "@dadi/cache": "^1.5.4",
+    "@dadi/cache": "^1.5.5",
     "@dadi/logger": "latest",
     "@dadi/status": "latest",
     "accept-language-parser": "^1.2.0",

--- a/test/acceptance/flush.js
+++ b/test/acceptance/flush.js
@@ -10,7 +10,7 @@ var config = require(__dirname + '/../../config')
 let bearerToken
 let configBackup
 
-describe('Cache', function () {
+describe.only('Cache', function () {
   this.timeout(10000)
 
   describe('Flush', function () {

--- a/test/acceptance/help.js
+++ b/test/acceptance/help.js
@@ -61,6 +61,7 @@ module.exports.imagesEqual = function ({base, headers, test}) {
 module.exports.getBearerToken = function (done) {
   request('http://' + config.get('server.host') + ':' + config.get('server.port'))
     .post(config.get('auth.tokenUrl'))
+    .set('host', 'localhost:80')
     .send({
       clientId: 'test',
       secret: 'test'

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -39,7 +39,7 @@ let server2 = nock('http://two.somedomain.tech')
     return fs.createReadStream(
       path.resolve(images['testdomain.com'])
     )
-  }) 
+  })
 
 let proxy = httpProxy.createProxyServer({})
 
@@ -334,7 +334,15 @@ describe('Multi-domain', function () {
 
                   cacheSet.restore()
 
-                  done()
+                  request(cdnUrl)
+                    .get('/test.jpg')
+                    .set('Host', 'localhost:80')
+                    .expect(200)
+                    .end((err, res) => {
+                      res.headers['x-cache'].should.eql('MISS')
+
+                      done()
+                    })
                 })
             }, 1000)
           })


### PR DESCRIPTION
This PR:

- Makes the `/api/flush` endpoint work with multiple domains. When multi-domain is enabled, the flush pattern becomes namespaced to the domain, i.e. flushing `*` means *all files for this domain*, instead of *all files* globally.

- Adds multi-domain cache flushing acceptance tests

- Adds compound key (array format) support to `cache.delete`

- Tidies up various things in the server module