### PR TITLE
Allow recipes to specify remote path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ notifications:
   slack: dadi:pnhiL60xOrm7GOglHUmb7xHK
   email: false
 node_js:
-  - '6.11.1'
+  - '8'
+  - 'node'
 before_script:
   - npm prune
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ notifications:
   email: false
 node_js:
   - '8'
-  - 'node'
 before_script:
   - npm prune
 branches:

--- a/dadi/lib/handlers/factory.js
+++ b/dadi/lib/handlers/factory.js
@@ -5,6 +5,7 @@ const logger = require('@dadi/logger')
 const mime = require('mime')
 const path = require('path')
 const url = require('url')
+const urljoin = require('url-join')
 
 const CSSHandler = require(path.join(__dirname, '/css'))
 const DefaultHandler = require(path.join(__dirname, '/default'))
@@ -159,12 +160,20 @@ HandlerFactory.prototype.createFromRecipe = function ({name, req, route, workspa
       .replace(new RegExp('^/' + name + '/'), '/')
       .replace(new RegExp('^/' + route + '/'), '/')
 
-    // Does the recipe specify a base path?
-    const fullPath = source.path
-      ? path.join(source.path, filePath)
-      : filePath
-
     if (typeof handler.setBaseUrl === 'function') {
+      let fullPath = filePath
+
+      // Does the recipe specify a base path?
+      if (source.path) {
+        // Is it a full URL?
+        if (/^http(s?):\/\//.test(source.path)) {
+          fullPath = urljoin(source.path, filePath)
+        } else {
+          // It's a relative path.
+          fullPath = path.join(source.path, filePath)
+        }
+      }
+
       handler.setBaseUrl(fullPath)
     }
 

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -635,9 +635,6 @@ ImageHandler.prototype.getLastModified = function () {
 }
 
 ImageHandler.prototype.parseUrl = function (url) {
-  // (!) A lot of this logic could be simplified if we used the WHATWG
-  // URL API (https://nodejs.org/api/url.html#url_the_whatwg_url_api),
-  // which required Node 7.
   let parsedUrl = urlParser.parse(url, true)
   let searchNodes = parsedUrl.search.split('?')
   let cdnUrl = `${parsedUrl.pathname}?${searchNodes.slice(-1)}`

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -212,7 +212,7 @@ ImageHandler.prototype.extractExifData = function (file) {
 }
 
 ImageHandler.prototype.get = function () {
-  let assetPath = this.parsedUrl.asset.path
+  let assetPath = this.parsedUrl.asset.href
 
   // (!) DEPRECATED
   //
@@ -635,11 +635,23 @@ ImageHandler.prototype.getLastModified = function () {
 }
 
 ImageHandler.prototype.parseUrl = function (url) {
-  const parsedUrl = urlParser.parse(url, true)
-  const searchNodes = parsedUrl.search.split('?')
-
+  // (!) A lot of this logic could be simplified if we used the WHATWG
+  // URL API (https://nodejs.org/api/url.html#url_the_whatwg_url_api),
+  // which required Node 7.
+  let parsedUrl = urlParser.parse(url, true)
+  let searchNodes = parsedUrl.search.split('?')
   let cdnUrl = `${parsedUrl.pathname}?${searchNodes.slice(-1)}`
   let assetUrl = parsedUrl.pathname
+
+  if (parsedUrl.protocol && parsedUrl.host) {
+    let baseUrl = `${parsedUrl.protocol}//${parsedUrl.host}`
+
+    if (parsedUrl.port) {
+      baseUrl += `:${parsedUrl.port}`
+    }
+
+    assetUrl = baseUrl + assetUrl
+  }
 
   if (searchNodes.length > 2) {
     assetUrl += `?${searchNodes.slice(-2, -1)}`

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -427,4 +427,5 @@ Server.prototype.stopFrequencyCache = function () {
 }
 
 module.exports = new Server()
+module.exports.config = config
 module.exports.Server = Server

--- a/dadi/lib/storage/factory.js
+++ b/dadi/lib/storage/factory.js
@@ -40,7 +40,6 @@ module.exports.create = function create (type, assetPath, {domain} = {}) {
   }
 
   let adapterFromPath = module.exports.extractAdapterFromPath(assetPath)
-
   let adapter
 
   if (adapterFromPath.adapter) {

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -76,22 +76,22 @@ HTTPStorage.prototype.get = function () {
       let expression = /Server responded with unhandled status: (\d*)/
       let match = (typeof error === 'string') && error.match(expression)
       let err = {
-        statusCode: (match && match[1]) || 400
+        statusCode: (match && parseInt(match[1])) || 400
       }
 
       switch (err.statusCode) {
-        case '404':
+        case 404:
           err.message = `Not Found: ${this.getFullUrl()}`
 
           break
 
-        case '403':
+        case 403:
           err.message = `Forbidden: ${this.getFullUrl()}`
 
           break
 
         default:
-          err.message = `Remote server responded with error code ${match[1]} for URL: ${this.getFullUrl()}`
+          err.message = `Remote server responded with error code ${err.statusCode} for URL: ${this.getFullUrl()}`
 
           break
       }

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -6,7 +6,7 @@ const mkdirp = require('mkdirp')
 const path = require('path')
 const sha1 = require('sha1')
 const urljoin = require('url-join')
-const wget = require('wget-improved')
+const wget = require('@dadi/wget')
 
 const tmpDirectory = path.resolve(path.join(__dirname, '/../../../workspace/_tmp'))
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@dadi/cache": "^1.5.5",
     "@dadi/logger": "latest",
     "@dadi/status": "latest",
+    "@dadi/wget@1.4.0": "^1.4.0",
     "accept-language-parser": "^1.2.0",
     "aspect-fit": "^1.0.2",
     "aws-sdk": "2.5.4",
@@ -63,8 +64,7 @@
     "url-join": "^3.0.0",
     "useragent": "2.3.0",
     "uuid": "latest",
-    "validate-commit-message": "^3.0.1",
-    "wget-improved": "git+https://github.com/jimlambie/node-wget"
+    "validate-commit-message": "^3.0.1"
   },
   "devDependencies": {
     "aws-sdk-mock": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "router": "~1.3.0",
     "sha1": "~1.1.1",
     "sharp": "^0.20.0",
-    "smartcrop-sharp": "dadi/smartcrop-sharp",
+    "smartcrop-sharp": "^2.0.2",
     "sqwish": "^0.2.2",
     "stream-length": "^1.0.2",
     "streamifier": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@dadi/cache": "^1.5.5",
     "@dadi/logger": "latest",
     "@dadi/status": "latest",
-    "@dadi/wget@1.4.0": "^1.4.0",
+    "@dadi/wget": "^1.4.0",
     "accept-language-parser": "^1.2.0",
     "aspect-fit": "^1.0.2",
     "aws-sdk": "2.5.4",

--- a/test/unit/imagehandler.js
+++ b/test/unit/imagehandler.js
@@ -150,7 +150,7 @@ describe('ImageHandler', function (done) {
     })
   })
 
-  it('should use HTTP Storage storage adapter when configured', function (done) {
+  it('should use HTTP Storage storage adapter when configured', () => {
     var newTestConfig = JSON.parse(testConfigString)
     newTestConfig.caching.directory.enabled = false
     newTestConfig.caching.redis.enabled = false
@@ -200,7 +200,7 @@ describe('ImageHandler', function (done) {
 
     // this is the test
     var im = new imageHandler('jpg', req)
-    im.get().then(function (stream) {
+    return im.get().then(function (stream) {
       factory.create.restore()
       HTTPStorage.HTTPStorage.prototype.get.restore()
       imageHandler.ImageHandler.prototype.convert.restore()
@@ -210,8 +210,6 @@ describe('ImageHandler', function (done) {
 
       var returnValue = spy.firstCall.returnValue
       returnValue.getFullUrl().should.eql(expected)
-
-      done()
     })
   })
 

--- a/test/unit/server.js
+++ b/test/unit/server.js
@@ -12,6 +12,16 @@ describe('Server', function () {
     done()
   })
 
+  it('should export the Server prototype', function (done) {
+    server.Server.should.be.Function
+    done()
+  })
+
+  it('should export the app config', function (done) {
+    server.config.should.be.Function
+    done()
+  })
+
   describe('start', function () {
     it('should set readyState', function (done) {
       var stub = sinon.stub(fs, 'readdirSync').callsFake(function () { return [] })


### PR DESCRIPTION
This PR allows recipes to specify the full URL of remote resources.

**workspace/recipes/my-recipe.json**
```json
{
  "recipe": "my-recipe",
  "path": "https://two.somedomain.tech/images"
}
```

Hitting https://cdn.somedomain.tech/my-recipe/test.jpg will load https://two.somedomain.tech/images/test.jpg even if `images.remote.path` is set to `https://one.somedomain.tech`.

Closes #254.