### PR TITLE
Handle the case where domains directory does not exist

### DIFF
--- a/config.js
+++ b/config.js
@@ -695,6 +695,10 @@ Config.prototype.get = function (path, domain) {
  * @return {Object}
  */
 Config.prototype.loadDomainConfigs = function () {
+  if (!this.get('multiDomain.enabled')) {
+    return {}
+  }
+
   let configs = {}
   let domainsDirectory = this.get('multiDomain.directory')
 

--- a/config.js
+++ b/config.js
@@ -608,7 +608,7 @@ const Config = function () {
   this.domainSchema = {}
   this.createDomainSchema(schema, this.domainSchema)
 
-  this.domainConfigs = this.loadDomainConfigs()
+  this.loadDomainConfigs()
 }
 
 Config.prototype = convict(schema)
@@ -724,6 +724,8 @@ Config.prototype.loadDomainConfigs = function () {
         )
       }    
     })
+
+  this.domainConfigs = configs
 
   return configs
 }

--- a/dadi/lib/models/domain-manager.js
+++ b/dadi/lib/models/domain-manager.js
@@ -39,18 +39,26 @@ DomainManager.prototype.getDomains = function () {
 DomainManager.prototype.scanDomains = function (domainsDirectory) {
   let domainsPath = path.resolve(domainsDirectory)
 
-  this.domains = fs.readdirSync(domainsPath).reduce((domains, domain) => {
-    let domainPath = path.join(domainsPath, domain)
+  try {
+    this.domains = fs.readdirSync(domainsPath).reduce((domains, domain) => {
+      let domainPath = path.join(domainsPath, domain)
 
-    if (fs.statSync(domainPath).isDirectory()) {
-      domains.push({
-        domain,
-        path: domainPath
-      })
+      if (fs.statSync(domainPath).isDirectory()) {
+        domains.push({
+          domain,
+          path: domainPath
+        })
+      }
+
+      return domains
+    }, [])
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error(`Domains directory (${domainsPath}) does not exist`)
     }
 
-    return domains
-  }, [])
+    throw err
+  }
 
   return this
 }

--- a/test/acceptance/auth.js
+++ b/test/acceptance/auth.js
@@ -108,6 +108,8 @@ describe('Authentication', function () {
     before(() => {
       config.set('multiDomain.enabled', true)
       config.set('multiDomain.directory', 'domains')
+
+      config.loadDomainConfigs()
     })
 
     after(() => {

--- a/test/acceptance/cache.js
+++ b/test/acceptance/cache.js
@@ -358,9 +358,11 @@ describe('Frequency cache flush', () => {
 
   describe('with multi-domain enabled', () => {
     it('should flush the entire cache in the interval defined by the `expireAt` property', done => {
+      config.set('multiDomain.enabled', true)
+      config.loadDomainConfigs()
+
       // Every second.
       config.set('caching.expireAt', '* * * * * *', 'testdomain.com')
-      config.set('multiDomain.enabled', true)
 
       app.start(() => {
         let mockCacheDelete = sinon.spy(cache.Cache.prototype, 'delete')


### PR DESCRIPTION
When the domains directory does not exist _and_ multi-domain is:

- disabled: nothing happens
- enabled: an error will be thrown with the message *«Domains directory (PATH) does not exist»*

Closes #345.

cc @adamkdean 