### PR TITLE
Include all image options in cache key

### DIFF
--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -291,7 +291,14 @@ ImageHandler.prototype.get = function () {
     {domain: this.req.__domain}
   )
 
+  // The cache key is formed by multiple parts which will be hashed
+  // separately, so that they can be used as search parameters for
+  // flushing, except for the first parameter, which contains the full
+  // set of options passed to the image engine. It's part of the cache
+  // key purely to make `/recipe1/a.jpg` and `/recipe1/b.jpg` map to
+  // different keys if the recipes contain different parameters.
   const cacheKey = [
+    sha1(JSON.stringify(this.options)),
     this.req.__domain,
     this.parsedUrl.cdn.pathname,
     this.parsedUrl.cdn.search.slice(1)

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -154,9 +154,7 @@ describe('Multi-domain', function () {
                 .expect(200)
                 .end((err, res) => {
                   res.headers['x-cache'].should.eql('HIT')
-                  cacheSet.getCall(0).args[1].should.eql([
-                    undefined, '/test.jpg', ''
-                  ])
+                  cacheSet.getCall(0).args[1].includes('testdomain.com').should.eql(false)
 
                   cacheSet.restore()
 
@@ -335,10 +333,7 @@ describe('Multi-domain', function () {
                 .expect(200)
                 .end((err, res) => {
                   res.headers['x-cache'].should.eql('HIT')
-                  cacheSet.getCall(0).args[1].should.eql([
-                    'testdomain.com', '/test.jpg', ''
-                  ])
-
+                  cacheSet.getCall(0).args[1].includes('testdomain.com').should.eql(true)
                   cacheSet.restore()
 
                   request(cdnUrl)


### PR DESCRIPTION
This PR fixes an issue where requests for the same image via different recipes would map to the same cache key, delivering the wrong result.