### PR TITLE
Return fallback image when remote server returns 404

### DIFF
--- a/dadi/lib/storage/disk.js
+++ b/dadi/lib/storage/disk.js
@@ -50,11 +50,11 @@ DiskStorage.prototype.get = function () {
         message: 'File not found: ' + this.getFullUrl()
       }
 
-      return new Missing().get().then((stream) => {
+      return new Missing().get().then(stream => {
         this.notFound = true
         this.lastModified = new Date()
         return resolve(stream)
-      }).catch((e) => {
+      }).catch(e => {
         console.log(e)
         return reject(err)
       })


### PR DESCRIPTION
This PR replicates the functionality of S3 and Disk storage where, if configured, a fallback image is returned to the consumer instead if just a JSON message.

Close #353 