### PR TITLE
Make config properties overridable at domain level

### DIFF
--- a/config.js
+++ b/config.js
@@ -211,7 +211,8 @@ const schema = {
       allowFullURL: {
         doc: 'If true, images can be loaded from any remote URL',
         format: Boolean,
-        default: true
+        default: true,
+        allowDomainOverride: true
       }
     }
   },

--- a/config.js
+++ b/config.js
@@ -126,18 +126,21 @@ const schema = {
     statusCode: {
       doc: 'If set, overrides the status code in the case of a 404',
       format: Number,
-      default: 404
+      default: 404,
+      allowDomainOverride: true
     },
     images: {
       enabled: {
         doc: 'If true, returns a default image when request returns a 404',
         format: Boolean,
-        default: false
+        default: false,
+        allowDomainOverride: true
       },
       path: {
         doc: 'The path to the default image',
         format: String,
-        default: './images/missing.png'
+        default: './images/missing.png',
+        allowDomainOverride: true
       }
     }
   },

--- a/config.js
+++ b/config.js
@@ -291,7 +291,8 @@ const schema = {
     ttl: {
       doc: '',
       format: Number,
-      default: 3600
+      default: 3600,
+      allowDomainOverride: true
     },
     directory: {
       enabled: {

--- a/config.js
+++ b/config.js
@@ -599,7 +599,8 @@ const schema = {
       doc: 'Whether to enable experimental support for on-demand JavaScript transpiling',
       format: Boolean,
       default: false,
-      env: 'JSTRANSPILING'
+      env: 'JSTRANSPILING',
+      allowDomainOverride: true
     }
   },
   multiDomain: {

--- a/config.js
+++ b/config.js
@@ -387,24 +387,28 @@ const schema = {
       doc: '',
       format: String,
       default: '1235488',
-      env: 'AUTH_TOKEN_ID'
+      env: 'AUTH_TOKEN_ID',
+      allowDomainOverride: true
     },
     secret: {
       doc: '',
       format: String,
       default: 'asd544see68e52',
-      env: 'AUTH_TOKEN_SECRET'
+      env: 'AUTH_TOKEN_SECRET',
+      allowDomainOverride: true
     },
     tokenTtl: {
       doc: '',
       format: Number,
       default: 1800,
-      env: 'AUTH_TOKEN_TTL'
+      env: 'AUTH_TOKEN_TTL',
+      allowDomainOverride: true
     },
     privateKey: {
       doc: 'Private key for signing JSON Web Tokens',
       format: String,
-      default: 'YOU-MUST-CHANGE-ME-NOW!'
+      default: 'YOU-MUST-CHANGE-ME-NOW!',
+      allowDomainOverride: true
     }
   },
   cloudfront: {

--- a/config.js
+++ b/config.js
@@ -462,16 +462,12 @@ const schema = {
       allowDomainOverride: true
     }
   },
-  gzip: {
-    doc: "If true, uses gzip compression and adds a 'Content-Encoding:gzip' header to the response",
-    format: Boolean,
-    default: true
-  },
   headers: {
     useGzipCompression: {
       doc: "If true, uses gzip compression and adds a 'Content-Encoding:gzip' header to the response.",
       format: Boolean,
-      default: true
+      default: true,
+      allowDomainOverride: true
     },
     cacheControl: {
       doc: 'A set of cache control headers based on specified mimetypes or paths',
@@ -484,7 +480,8 @@ const schema = {
           {'text/javascript': 'public, max-age=86400'},
           {'application/javascript': 'public, max-age=86400'}
         ]
-      }
+      },
+      allowDomainOverride: true
     }
   },
   feedback: {

--- a/dadi/lib/auth/index.js
+++ b/dadi/lib/auth/index.js
@@ -39,7 +39,7 @@ module.exports = function (router) {
       return fail('NoToken', res)
     }
 
-    jwt.verify(token, config.get('auth.privateKey'), (err, decoded) => {
+    jwt.verify(token, config.get('auth.privateKey', req.__domain), (err, decoded) => {
       if (err || (decoded.domain !== req.__domain)) {
         return fail('InvalidToken', res)
       }
@@ -60,8 +60,8 @@ module.exports = function (router) {
     let secret = req.body.secret
 
     if (
-      clientId !== config.get('auth.clientId') ||
-      secret !== config.get('auth.secret')
+      clientId !== config.get('auth.clientId', req.__domain) ||
+      secret !== config.get('auth.secret', req.__domain)
     ) {
       return fail('NoAccess', res)
     }
@@ -71,8 +71,8 @@ module.exports = function (router) {
     }
 
     // Sign a JWT token.
-    jwt.sign(payload, config.get('auth.privateKey'), {
-      expiresIn: config.get('auth.tokenTtl')
+    jwt.sign(payload, config.get('auth.privateKey', req.__domain), {
+      expiresIn: config.get('auth.tokenTtl', req.__domain)
     }, (err, token) => {
       if (err) {
         logger.error({module: 'auth'}, err)

--- a/dadi/lib/cache/index.js
+++ b/dadi/lib/cache/index.js
@@ -17,10 +17,11 @@ const Cache = function () {}
  * Adds a stream to the cache
  * @param  {Stream}  stream   The stream to be cached
  * @param  {String}  key      The cache key
+ * @param  {Object}  options  Optional options object
  * @param  {Boolean} wait     Whether to wait for the write operation
  * @return {Promise}
  */
-Cache.prototype.cacheFile = function (stream, key, wait) {
+Cache.prototype.cacheFile = function (stream, key, options, wait) {
   if (!this.isEnabled()) return Promise.resolve(stream)
 
   let encryptedKey = this.getNormalisedKey(key)
@@ -30,7 +31,7 @@ Cache.prototype.cacheFile = function (stream, key, wait) {
   stream.pipe(cacheStream)
   stream.pipe(responseStream)
 
-  let write = cache.set(encryptedKey, cacheStream)
+  let write = cache.set(encryptedKey, cacheStream, options)
 
   if (wait) {
     return write.then(() => responseStream)
@@ -87,15 +88,16 @@ Cache.prototype.getNormalisedKey = function (key) {
  * Will return a Promise that is resolved with the Stream
  * if the cache key exists, or resolved with null otherwise.
  *
- * @param  {String} key The cache key
+ * @param  {String} key     The cache key
+ * @param  {Object} options Optional options object
  * @return {Promise}
  */
-Cache.prototype.getStream = function (key) {
+Cache.prototype.getStream = function (key, options) {
   if (!this.isEnabled()) return Promise.resolve(null)
 
   let encryptedKey = this.getNormalisedKey(key)
 
-  return cache.get(encryptedKey).catch(err => { // eslint-disable-line handle-callback-err
+  return cache.get(encryptedKey, options).catch(err => { // eslint-disable-line handle-callback-err
     return null
   })
 }

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -46,7 +46,7 @@ const Controller = function (router) {
         this.addLastModifiedHeader(res, handler)
 
         if (handler.storageHandler && handler.storageHandler.notFound) {
-          res.statusCode = config.get('notFound.statusCode') || 404
+          res.statusCode = config.get('notFound.statusCode', req.__domain) || 404
         }
 
         if (handler.storageHandler && handler.storageHandler.cleanUp) {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -42,7 +42,7 @@ const Controller = function (router) {
     factory.create(req).then(handler => {
       return handler.get().then(stream => {
         this.addContentTypeHeader(res, handler)
-        this.addCacheControlHeader(res, handler)
+        this.addCacheControlHeader(res, handler, req.__domain)
         this.addLastModifiedHeader(res, handler)
 
         if (handler.storageHandler && handler.storageHandler.notFound) {
@@ -79,7 +79,10 @@ const Controller = function (router) {
 
         var concatStream = concat(sendBuffer)
 
-        if (config.get('headers.useGzipCompression') && handler.contentType() !== 'application/json') {
+        if (
+          config.get('headers.useGzipCompression', req.__domain) &&
+          handler.contentType() !== 'application/json'
+        ) {
           res.setHeader('Content-Encoding', 'gzip')
 
           var gzipStream = stream.pipe(zlib.createGzip())
@@ -171,13 +174,13 @@ Controller.prototype.addLastModifiedHeader = function (res, handler) {
   }
 }
 
-Controller.prototype.addCacheControlHeader = function (res, handler) {
-  var configHeaderSets = config.get('headers.cacheControl')
+Controller.prototype.addCacheControlHeader = function (res, handler, domain) {
+  let configHeaderSets = config.get('headers.cacheControl', domain)
 
   // If it matches, sets Cache-Control header using the file path
   configHeaderSets.paths.forEach(obj => {
-    var key = Object.keys(obj)[0]
-    var value = obj[key]
+    let key = Object.keys(obj)[0]
+    let value = obj[key]
 
     if (handler.storageHandler.getFullUrl().indexOf(key) > -1) {
       setHeader(value)
@@ -186,8 +189,8 @@ Controller.prototype.addCacheControlHeader = function (res, handler) {
 
   // If not already set, sets Cache-Control header using the file mimetype
   configHeaderSets.mimetypes.forEach(obj => {
-    var key = Object.keys(obj)[0]
-    var value = obj[key]
+    let key = Object.keys(obj)[0]
+    let value = obj[key]
 
     if (handler.getFilename && (mime.lookup(handler.getFilename()) === key)) {
       setHeader(value)

--- a/dadi/lib/controller/recipe.js
+++ b/dadi/lib/controller/recipe.js
@@ -6,23 +6,15 @@ const Recipe = require(path.join(__dirname, '/../models/recipe'))
 const workspace = require(path.join(__dirname, '/../models/workspace'))
 
 module.exports.post = (req, res) => {
+  let obj = typeof req.body === 'object'
+    ? req.body
+    : JSON.parse(req.body)
+
   // Don't accept an empty POST
-  if (Object.keys(req.body).length === 0) {
+  if (Object.keys(obj).length === 0) {
     return help.sendBackJSON(400, {
       success: false,
       errors: ['Bad Request']
-    }, res)
-  }
-
-  let obj
-
-  // Valid JSON?
-  try {
-    obj = typeof req.body === 'object' ? req.body : JSON.parse(req.body)
-  } catch (err) {
-    return help.sendBackJSON(400, {
-      success: false,
-      errors: ['Invalid JSON Syntax']
     }, res)
   }
 

--- a/dadi/lib/handlers/css.js
+++ b/dadi/lib/handlers/css.js
@@ -54,7 +54,9 @@ CSSHandler.prototype.contentType = function () {
  * @return {Promise} A stream with the file
  */
 CSSHandler.prototype.get = function () {
-  return this.cache.getStream(this.cacheKey).then(stream => {
+  return this.cache.getStream(this.cacheKey, {
+    ttl: config.get('caching.ttl', this.req.__domain)
+  }).then(stream => {
     if (stream) {
       this.isCached = true
 
@@ -70,7 +72,9 @@ CSSHandler.prototype.get = function () {
     return this.storageHandler.get().then(stream => {
       return this.transform(stream)
     }).then(stream => {
-      return this.cache.cacheFile(stream, this.cacheKey)
+      return this.cache.cacheFile(stream, this.cacheKey, {
+        ttl: config.get('caching.ttl', this.req.__domain)
+      })
     })
   })
 }

--- a/dadi/lib/handlers/css.js
+++ b/dadi/lib/handlers/css.js
@@ -5,7 +5,7 @@ const path = require('path')
 const url = require('url')
 
 const Cache = require(path.join(__dirname, '/../cache'))
-// const config = require(path.join(__dirname, '/../../../config'))
+const config = require(path.join(__dirname, '/../../../config'))
 const StorageFactory = require(path.join(__dirname, '/../storage/factory'))
 
 /**
@@ -31,9 +31,15 @@ const CSSHandler = function (format, req, {
   )
 
   this.cache = Cache()
-  this.cacheKey = this.url.href + JSON.stringify({
-    compress: this.isCompressed
-  })
+  this.cacheKey = [
+    req.__domain,
+    this.url.href,
+    JSON.stringify({
+      compress: this.isCompressed
+    })
+  ]
+
+  this.req = req
 
   this.storageFactory = Object.create(StorageFactory)
   this.storageHandler = null

--- a/dadi/lib/handlers/default.js
+++ b/dadi/lib/handlers/default.js
@@ -44,7 +44,9 @@ DefaultHandler.prototype.contentType = function () {
  * @return {Promise} A stream with the file
  */
 DefaultHandler.prototype.get = function () {
-  return this.cache.getStream(this.cacheKey).then(stream => {
+  return this.cache.getStream(this.cacheKey, {
+    ttl: config.get('caching.ttl', this.req.__domain)
+  }).then(stream => {
     if (stream) {
       this.isCached = true
 
@@ -58,7 +60,9 @@ DefaultHandler.prototype.get = function () {
     )
 
     return this.storageHandler.get().then(stream => {
-      return this.cache.cacheFile(stream, this.cacheKey)
+      return this.cache.cacheFile(stream, this.cacheKey, {
+        ttl: config.get('caching.ttl', this.req.__domain)
+      })
     })
   })
 }

--- a/dadi/lib/handlers/default.js
+++ b/dadi/lib/handlers/default.js
@@ -3,7 +3,7 @@ const path = require('path')
 const url = require('url')
 
 const Cache = require(path.join(__dirname, '/../cache'))
-// const config = require(path.join(__dirname, '/../../../config'))
+const config = require(path.join(__dirname, '/../../../config'))
 const StorageFactory = require(path.join(__dirname, '/../storage/factory'))
 
 /**
@@ -23,7 +23,9 @@ const DefaultHandler = function (format, req, {
   )
 
   this.cache = Cache()
-  this.cacheKey = this.url.href
+  this.cacheKey = [req.__domain, this.url.href]
+
+  this.req = req
 
   this.storageFactory = Object.create(StorageFactory)
   this.storageHandler = null

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -114,7 +114,21 @@ ImageHandler.prototype.contentType = function () {
     return 'application/json'
   }
 
-  switch (this.format.toLowerCase()) {
+  let outputFormat = this.format
+
+  // If the fallback image is to be delivered, the content type
+  // will need to match its format, not the format of the original
+  // file.
+  if (
+    this.storageHandler.notFound &&
+    config.get('notFound.images.enabled', this.req.__domain)
+  ) {
+    outputFormat = path.extname(
+      config.get('notFound.images.path')
+    ).slice(1)
+  }
+
+  switch (outputFormat.toLowerCase()) {
     case 'png':
       return 'image/png'
     case 'jpg':
@@ -1075,32 +1089,28 @@ function getColours (buffer, options) {
  * @returns {object}
  */
 function getImageOptionsFromLegacyURL (optionsArray) {
-  var legacyURLFormat = optionsArray.length < 17
+  let superLegacyFormatOffset = optionsArray.length === 13
+    ? 0
+    : 4
 
-  var gravity = optionsArray[optionsArray.length - 6].substring(0, 1).toUpperCase() + optionsArray[optionsArray.length - 6].substring(1)
-  var filter = optionsArray[optionsArray.length - 5].substring(0, 1).toUpperCase() + optionsArray[optionsArray.length - 5].substring(1)
-
-  var options = {
+  let options = {
     format: optionsArray[0],
     quality: optionsArray[1],
     trim: optionsArray[2],
     trimFuzz: optionsArray[3],
     width: optionsArray[4],
     height: optionsArray[5],
-
-    /* legacy client applications don't send the next 4 */
-    cropX: legacyURLFormat ? '0' : optionsArray[6],
-    cropY: legacyURLFormat ? '0' : optionsArray[7],
-    ratio: legacyURLFormat ? '0' : optionsArray[8],
-    devicePixelRatio: legacyURLFormat ? 1 : optionsArray[9],
-
-    resizeStyle: optionsArray[optionsArray.length - 7],
-    gravity: gravity,
-    filter: filter,
-    blur: optionsArray[optionsArray.length - 4],
-    strip: optionsArray[optionsArray.length - 3],
-    rotate: optionsArray[optionsArray.length - 2],
-    flip: optionsArray[optionsArray.length - 1]
+    cropX: (superLegacyFormatOffset === 0) ? '0' : optionsArray[6],
+    cropY: (superLegacyFormatOffset === 0) ? '0' : optionsArray[7],
+    ratio: (superLegacyFormatOffset === 0) ? '0' : optionsArray[8],
+    devicePixelRatio: (superLegacyFormatOffset === 0) ? '0' : optionsArray[9],
+    resizeStyle: optionsArray[6 + superLegacyFormatOffset],
+    gravity: optionsArray[7 + superLegacyFormatOffset],
+    filter: optionsArray[8 + superLegacyFormatOffset],
+    blur: optionsArray[9 + superLegacyFormatOffset],
+    strip: optionsArray[10 + superLegacyFormatOffset],
+    rotate: optionsArray[11 + superLegacyFormatOffset],
+    flip: optionsArray[12 + superLegacyFormatOffset]
   }
 
   return options

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -262,11 +262,11 @@ ImageHandler.prototype.get = function () {
   if (
     this.isExternalUrl &&
     (
-      !config.get('images.remote.enabled') ||
-      !config.get('images.remote.allowFullURL')
+      !config.get('images.remote.enabled', this.req.__domain) ||
+      !config.get('images.remote.allowFullURL', this.req.__domain)
     )
   ) {
-    const err = {
+    let err = {
       statusCode: 403,
       message: 'Loading images from a full remote URL is not supported by this instance of DADI CDN'
     }

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -319,7 +319,9 @@ ImageHandler.prototype.get = function () {
   ]
   const isJSONResponse = this.options.format === 'json'
 
-  return this.cache.getStream(cacheKey).then(cachedStream => {
+  return this.cache.getStream(cacheKey, {
+    ttl: config.get('caching.ttl', this.req.__domain)
+  }).then(cachedStream => {
     if (cachedStream) {
       this.isCached = true
 
@@ -404,7 +406,10 @@ ImageHandler.prototype.get = function () {
         if (!this.isCached && !this.storageHandler.notFound) {
           this.cache.cacheFile(
             this.options.format === 'json' ? responseStream : this.cacheStream,
-            cacheKey
+            cacheKey,
+            {
+              ttl: config.get('caching.ttl', this.req.__domain)
+            }
           )
         }
 

--- a/dadi/lib/handlers/js.js
+++ b/dadi/lib/handlers/js.js
@@ -58,7 +58,9 @@ JSHandler.prototype.get = function () {
     this.cacheKey += this.getBabelPluginsHash()
   }
 
-  return this.cache.getStream(this.cacheKey).then(stream => {
+  return this.cache.getStream(this.cacheKey, {
+    ttl: config.get('caching.ttl', this.req.__domain)
+  }).then(stream => {
     if (stream) {
       this.isCached = true
 
@@ -74,7 +76,9 @@ JSHandler.prototype.get = function () {
     return this.storageHandler.get().then(stream => {
       return this.transform(stream)
     }).then(stream => {
-      return this.cache.cacheFile(stream, this.cacheKey)
+      return this.cache.cacheFile(stream, this.cacheKey, {
+        ttl: config.get('caching.ttl', this.req.__domain)
+      })
     })
   })
 }

--- a/dadi/lib/handlers/js.js
+++ b/dadi/lib/handlers/js.js
@@ -31,6 +31,8 @@ const JSHandler = function (format, req, {
   this.cache = Cache()
   this.cacheKey = this.url.href
 
+  this.req = req
+
   this.storageFactory = Object.create(StorageFactory)
   this.storageHandler = null
 
@@ -209,7 +211,9 @@ JSHandler.prototype.getLegacyURLOverrides = function (url) {
  */
 JSHandler.prototype.isTransformEnabled = function () {
   // Currently behind a feature flag.
-  if (!config.get('experimental.jsTranspiling')) return false
+  if (!config.get('experimental.jsTranspiling', this.req.__domain)) {
+    return false
+  }
 
   return (this.url.query.transform || (this.options.transform === true))
 }

--- a/dadi/lib/handlers/js.js
+++ b/dadi/lib/handlers/js.js
@@ -29,7 +29,7 @@ const JSHandler = function (format, req, {
   )
 
   this.cache = Cache()
-  this.cacheKey = this.url.href
+  this.cacheKey = [req.__domain, this.url.href]
 
   this.req = req
 

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -194,6 +194,16 @@ Server.prototype.start = function (done) {
   })
 
   router.use(bodyParser.json({limit: '50mb'}))
+  router.use((err, req, res, next) => {
+    if (err) {
+      return help.sendBackJSON(400, {
+        success: false,
+        errors: ['Invalid JSON Syntax']
+      }, res)
+    }
+
+    next()
+  })
 
   router.get('/', function (req, res, next) {
     res.end('Welcome to DADI CDN')

--- a/dadi/lib/storage/disk.js
+++ b/dadi/lib/storage/disk.js
@@ -5,9 +5,10 @@ const path = require('path')
 
 const Missing = require(path.join(__dirname, '/missing'))
 
-const DiskStorage = function ({assetType = 'assets', url}) {
+const DiskStorage = function ({assetType = 'assets', domain, url}) {
   let assetPath = config.get(`${assetType}.directory.path`)
 
+  this.domain = domain
   this.url = nodeUrl.parse(url, true).pathname
   this.path = path.resolve(assetPath)
 }
@@ -50,7 +51,9 @@ DiskStorage.prototype.get = function () {
         message: 'File not found: ' + this.getFullUrl()
       }
 
-      return new Missing().get().then(stream => {
+      return new Missing().get({
+        domain: this.domain
+      }).then(stream => {
         this.notFound = true
         this.lastModified = new Date()
         return resolve(stream)

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -31,6 +31,7 @@ const HTTPStorage = function ({assetType = 'assets', domain, url}) {
     this.baseUrl = remoteAddress
   }
 
+  this.domain = domain
   this.url = url
 }
 
@@ -104,7 +105,9 @@ HTTPStorage.prototype.get = function () {
       }
 
       if (err.statusCode === 404) {
-        return new Missing().get().then(stream => {
+        return new Missing().get({
+          domain: this.domain
+        }).then(stream => {
           this.notFound = true
           this.lastModified = new Date()
           return resolve(stream)

--- a/dadi/lib/storage/s3.js
+++ b/dadi/lib/storage/s3.js
@@ -6,7 +6,7 @@ const stream = require('stream')
 const logger = require('@dadi/logger')
 const Missing = require(path.join(__dirname, '/missing'))
 
-const S3Storage = function ({assetType = 'assets', url}) {
+const S3Storage = function ({assetType = 'assets', domain, url}) {
   this.providerType = 'Amazon S3'
 
   AWS.config.update({
@@ -29,6 +29,7 @@ const S3Storage = function ({assetType = 'assets', url}) {
   }
 
   this.bucketName = config.get(`${assetType}.s3.bucketName`)
+  this.domain = domain
   this.url = url
   this.urlParts = this.getUrlParts(url)
   this.s3 = new AWS.S3()
@@ -68,7 +69,9 @@ S3Storage.prototype.get = function () {
     },
     (error) => {
       if (error.statusCode === 404) {
-        return new Missing().get().then(stream => {
+        return new Missing().get({
+          domain: this.domain
+        }).then(stream => {
           this.notFound = true
           this.lastModified = new Date()
           return resolve(stream)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "init": "validate-commit-msg",
     "start": "node index.js --node_env=development",
-    "test": "standard 'dadi/**/*.js' && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test",
+    "test": "rm -f config/config.test.json && standard 'dadi/**/*.js' && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test",
     "posttest": "./scripts/coverage.js"
   },
   "dependencies": {

--- a/test/acceptance/auth.js
+++ b/test/acceptance/auth.js
@@ -181,5 +181,137 @@ describe('Authentication', function () {
             })
         })
     })
+
+    it('should validate the clientId/secret as per the domain configuration', done => {
+      config.set('auth.clientId', 'testClient1', 'localhost')
+      config.set('auth.secret', 'superSecret1', 'localhost')
+      config.set('auth.privateKey', 'privateKey1', 'localhost')
+
+      config.set('auth.clientId', 'testClient2', 'testdomain.com')
+      config.set('auth.secret', 'superSecret2', 'testdomain.com')
+      config.set('auth.privateKey', 'privateKey2', 'testdomain.com')
+
+      request(cdnUrl)
+        .post(tokenRoute)
+        .send({
+          clientId: 'test',
+          secret: 'test'
+        })
+        .set('host', 'localhost:80')
+        .expect('content-type', 'application/json')
+        .expect('pragma', 'no-cache')
+        .expect('Cache-Control', 'no-store')
+        .expect(401)
+        .end((err, res) => {
+          request(cdnUrl)
+            .post(tokenRoute)
+            .send({
+              clientId: 'test',
+              secret: 'test'
+            })
+            .set('host', 'testdomain.com:80')
+            .expect('content-type', 'application/json')
+            .expect('pragma', 'no-cache')
+            .expect('Cache-Control', 'no-store')
+            .expect(401)
+            .end((err, res) => {
+              request(cdnUrl)
+                .post(tokenRoute)
+                .send({
+                  clientId: 'testClient1',
+                  secret: 'superSecret1'
+                })
+                .set('host', 'localhost:80')
+                .expect('content-type', 'application/json')
+                .expect('pragma', 'no-cache')
+                .expect('Cache-Control', 'no-store')
+                .expect(200)
+                .end((err, res) => {
+                  res.body.accessToken.should.be.String
+
+                  request(cdnUrl)
+                    .post(tokenRoute)
+                    .send({
+                      clientId: 'testClient2',
+                      secret: 'superSecret2'
+                    })
+                    .set('host', 'testdomain.com:80')
+                    .expect('content-type', 'application/json')
+                    .expect('pragma', 'no-cache')
+                    .expect('Cache-Control', 'no-store')
+                    .expect(200)
+                    .end((err, res) => {
+                      res.body.accessToken.should.be.String
+
+                      done()
+                    })
+                })
+            })
+        })
+    })
+
+    it('should encode JWTs with the private key and TTL defined for each domain', done => {
+      config.set('auth.clientId', 'testClient1', 'localhost')
+      config.set('auth.secret', 'superSecret1', 'localhost')
+      config.set('auth.privateKey', 'privateKey1', 'localhost')
+      config.set('auth.tokenTtl', 10000, 'localhost')
+
+      config.set('auth.clientId', 'testClient2', 'testdomain.com')
+      config.set('auth.secret', 'superSecret2', 'testdomain.com')
+      config.set('auth.privateKey', 'privateKey2', 'testdomain.com')
+      config.set('auth.tokenTtl', 20000, 'testdomain.com')
+
+      let startTime = Math.floor(Date.now() / 1000)
+
+      request(cdnUrl)
+        .post(tokenRoute)
+        .send({
+          clientId: 'testClient1',
+          secret: 'superSecret1'
+        })
+        .set('host', 'localhost:80')
+        .expect('content-type', 'application/json')
+        .expect('pragma', 'no-cache')
+        .expect('Cache-Control', 'no-store')
+        .expect(200)
+        .end((err, res) => {
+          jwt.verify(
+            res.body.accessToken,
+            'privateKey1',
+            (err, decoded) => {
+              if (err) return done(err)
+
+              (decoded.exp - startTime).should.eql(10000)
+              decoded.domain.should.eql('localhost')
+
+              request(cdnUrl)
+                .post(tokenRoute)
+                .send({
+                  clientId: 'testClient2',
+                  secret: 'superSecret2'
+                })
+                .set('host', 'testdomain.com:80')
+                .expect('content-type', 'application/json')
+                .expect('pragma', 'no-cache')
+                .expect('Cache-Control', 'no-store')
+                .expect(200)
+                .end((err, res) => {
+                  jwt.verify(
+                    res.body.accessToken,
+                    'privateKey2',
+                    (err, decoded) => {
+                      if (err) return done(err)
+
+                      (decoded.exp - startTime).should.eql(20000)
+                      decoded.domain.should.eql('testdomain.com')
+
+                      done()
+                    }
+                  )
+                })
+            }
+          )
+        })
+    })
   })
 })

--- a/test/acceptance/cache.js
+++ b/test/acceptance/cache.js
@@ -23,19 +23,17 @@ const USER_AGENTS = {
 describe('Cache', function () {
   this.timeout(10000)
 
+  before(() => {
+    config.set('caching.directory.enabled', true)
+    config.set('caching.redis.enabled', false)
+  })
+
+  after(() => {
+    config.set('caching.directory.enabled', configBackup.caching.directory.enabled)
+    config.set('caching.redis.enabled', configBackup.caching.redis.enabled)
+  })
+
   beforeEach(done => {
-    let newTestConfig = JSON.parse(fs.readFileSync(config.configPath()))
-
-    newTestConfig.caching.directory.enabled = true
-    newTestConfig.caching.redis.enabled = false
-
-    cache.reset()
-    help.clearCache()
-
-    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
-
-    config.loadFile(config.configPath())
-
     app.start(function () {
       help.getBearerToken((err, token) => {
         if (err) return done(err)

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -206,6 +206,31 @@ describe('Multi-domain', function () {
       })
     }).timeout(5000)
 
+    it('should use the allowFullURL setting defined at domain level to determine whether or not a request with a full remote URL will be served', done => {
+      config.set('images.remote.allowFullURL', true, 'localhost')
+      config.set('images.remote.allowFullURL', false, 'testdomain.com')
+
+      request(cdnUrl)
+        .get('/http://one.somedomain.tech/test.jpg')
+        .set('Host', 'localhost:80')
+        .expect(200)
+        .end((err, res) => {
+          res.headers['content-type'].should.eql('image/jpeg')
+
+          request(cdnUrl)
+            .get('/http://one.somedomain.tech/test.jpg')
+            .set('Host', 'testdomain.com:80')
+            .end((err, res) => {
+              res.statusCode.should.eql(403)
+              res.body.message.should.eql(
+                'Loading images from a full remote URL is not supported by this instance of DADI CDN'
+              )
+
+              done()
+            })
+        })
+    }).timeout(5000)
+
     describe('when the target domain is not configured', () => {
       let testDomain = 'unknowndomain.com'
 

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -1,13 +1,10 @@
 const fs = require('fs')
-const http = require('http')
-const httpProxy = require('http-proxy')
 const nock = require('nock')
 const path = require('path')
 const sha1 = require('sha1')
 const should = require('should')
 const sinon = require('sinon')
 const request = require('supertest')
-const url = require('url')
 
 const app = require(__dirname + '/../../dadi/lib/')
 const Cache = require(__dirname + '/../../dadi/lib/cache')
@@ -15,14 +12,12 @@ const config = require(__dirname + '/../../config')
 const help = require(__dirname + '/help')
 
 const cdnUrl = `http://${config.get('server.host')}:${config.get('server.port')}`
-const proxyPort = config.get('server.port') + 1
-const proxyUrl = `http://localhost:${proxyPort}`
-
 const images = {
   'localhost': 'test/images/test.jpg',
   'testdomain.com': 'test/images/dog-w600.jpeg'
 }
 
+let configBackup = config.get()
 let server1 = nock('http://one.somedomain.tech')
   .get('/test.jpg')
   .times(Infinity)
@@ -41,45 +36,24 @@ let server2 = nock('http://two.somedomain.tech')
     )
   })
 
-let proxy = httpProxy.createProxyServer({})
-
-proxy.on('proxyReq', (proxyReq, req, res, options) => {
-  let parsedUrl = url.parse(req.url, true)
-  let mockDomain = parsedUrl.query.mockdomain
-
-  parsedUrl.search = null
-  delete parsedUrl.query.mockdomain
-
-  proxyReq.path = url.format(parsedUrl)
-  proxyReq.setHeader('Host', mockDomain)
-})
-
-let proxyServer = http.createServer((req, res) => {
-  proxy.web(req, res, {
-    target: cdnUrl
-  })
-})
-
 describe('Multi-domain', function () {
   describe('if multi-domain is disabled', () => {
-    let configBackup = {
-      multiDomain: config.get('multiDomain')
-    }
-
     before(done => {
       config.set('multiDomain.enabled', false)
 
-      app.start(err => {
-        if (err) return done(err)
+      help.proxyStart().then(() => {
+        app.start(err => {
+          if (err) return done(err)
 
-        setTimeout(done, 500)
+          setTimeout(done, 500)
+        })  
       })
     })
 
     after(done => {
       config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
 
-      proxyServer.close(() => {
+      help.proxyStop().then(() => {
         app.stop(done)  
       })
     })
@@ -93,7 +67,7 @@ describe('Multi-domain', function () {
 
         return help.imagesEqual({
           base: images['localhost'],
-          test: `${cdnUrl}/sample-image-recipe/test.jpg?mockdomain=unknowndomain.com`
+          test: `${help.proxyUrl}/sample-image-recipe/test.jpg?mockdomain=unknowndomain.com`
         }).then(match => {
           match.should.eql(true)
         })
@@ -109,7 +83,7 @@ describe('Multi-domain', function () {
 
         return help.imagesEqual({
           base: images['localhost'],
-          test: `${cdnUrl}/test.jpg?mockdomain=unknowndomain.com`
+          test: `${help.proxyUrl}/test.jpg?mockdomain=unknowndomain.com`
         }).then(match => {
           match.should.eql(true)
         })
@@ -117,8 +91,6 @@ describe('Multi-domain', function () {
     }).timeout(5000)
 
     describe('Caching', () => {
-      let configBackup = config.get('caching')
-
       beforeEach(() => {
         help.clearCache()
 
@@ -130,8 +102,8 @@ describe('Multi-domain', function () {
         help.clearCache()
         Cache.reset()
 
-        config.set('caching.redis.enabled', configBackup.redis.enabled)
-        config.set('caching.directory.enabled', configBackup.directory.enabled)
+        config.set('caching.redis.enabled', configBackup.caching.redis.enabled)
+        config.set('caching.directory.enabled', configBackup.caching.directory.enabled)
       })
 
       it('should not include domain name as part of cache key', done => {
@@ -167,11 +139,6 @@ describe('Multi-domain', function () {
   })
 
   describe('if multi-domain is enabled', () => {
-    let configBackup = {
-      images: config.get('images'),
-      multiDomain: config.get('multiDomain')
-    }
-
     beforeEach(done => {
       config.set('images.s3.enabled', false)
 
@@ -187,8 +154,8 @@ describe('Multi-domain', function () {
       app.start(err => {
         if (err) return done(err)
 
-        proxyServer.listen(proxyPort, () => {
-          setTimeout(done, 500)  
+        help.proxyStart().then(() => {
+          setTimeout(done, 500)
         })
       })
     })
@@ -202,21 +169,21 @@ describe('Multi-domain', function () {
 
       config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
 
-      proxyServer.close(() => {
-        app.stop(done)  
+      help.proxyStop().then(() => {
+        app.stop(done)
       })
     })
 
     it('should retrieve a remote image from the path specified by a recipe at domain level', () => {
       return help.imagesEqual({
         base: images['localhost'],
-        test: `${proxyUrl}/test-recipe/test.jpg?mockdomain=localhost`
+        test: `${help.proxyUrl}/test-recipe/test.jpg?mockdomain=localhost`
       }).then(match => {
         match.should.eql(true)
 
         return help.imagesEqual({
           base: images['testdomain.com'],
-          test: `${proxyUrl}/test-recipe/test.jpg?mockdomain=testdomain.com`
+          test: `${help.proxyUrl}/test-recipe/test.jpg?mockdomain=testdomain.com`
         }).then(match => {
           match.should.eql(true)
         })
@@ -226,13 +193,13 @@ describe('Multi-domain', function () {
     it('should retrieve a remote image from the path specified by the domain config', () => {
       return help.imagesEqual({
         base: images['localhost'],
-        test: `${proxyUrl}/test.jpg?mockdomain=localhost`
+        test: `${help.proxyUrl}/test.jpg?mockdomain=localhost`
       }).then(match => {
         match.should.eql(true)
 
         return help.imagesEqual({
           base: images['testdomain.com'],
-          test: `${proxyUrl}/test.jpg?mockdomain=testdomain.com`
+          test: `${help.proxyUrl}/test.jpg?mockdomain=testdomain.com`
         }).then(match => {
           match.should.eql(true)
         })
@@ -296,8 +263,6 @@ describe('Multi-domain', function () {
     })
 
     describe('Caching', () => {
-      let configBackup = config.get('caching')
-
       beforeEach(() => {
         help.clearCache()
 
@@ -309,8 +274,8 @@ describe('Multi-domain', function () {
         help.clearCache()
         Cache.reset()
 
-        config.set('caching.redis.enabled', configBackup.redis.enabled)
-        config.set('caching.directory.enabled', configBackup.directory.enabled)
+        config.set('caching.redis.enabled', configBackup.caching.redis.enabled)
+        config.set('caching.directory.enabled', configBackup.caching.directory.enabled)
       })
 
       it('should include domain name as part of cache key', done => {

--- a/test/acceptance/recipes.js
+++ b/test/acceptance/recipes.js
@@ -12,6 +12,7 @@ const app = require(__dirname + '/../../dadi/lib/')
 const imageHandler = require(__dirname + '/../../dadi/lib/handlers/image')
 
 let config = require(__dirname + '/../../config')
+let configBackup = config.get()
 let cdnUrl = `http://${config.get('server.host')}:${config.get('server.port')}`
 let testConfigString
 
@@ -300,6 +301,8 @@ describe('Recipes', function () {
         .get('/thumbxx/test.jpg')
         .reply(404)
 
+      config.set('notFound.images.enabled', false)
+
       help.getBearerToken((err, token) => {
         request(cdnUrl)
         .post('/api/recipes')
@@ -314,6 +317,9 @@ describe('Recipes', function () {
             .end(function (err, res) {
               res.statusCode.should.eql(404)
               res.body.statusCode.should.eql(404)
+
+              config.set('notFound.images.enabled', configBackup.notFound.images.enabled)
+
               done()
             })
           }, 500)
@@ -558,7 +564,6 @@ describe('Recipes', function () {
 })
 
 describe('Recipes (with multi-domain)', () => {
-  let configBackup = config.get()
   let sample = {
     recipe: 'test-domain-recipe',
     settings: {

--- a/test/acceptance/recipes.js
+++ b/test/acceptance/recipes.js
@@ -92,7 +92,26 @@ describe('Recipes', function () {
           .post('/api/recipes')
           .send({})
           .set('Authorization', 'Bearer ' + token)
-          .expect(400, done)
+          .expect(400, (err, res) => {
+            res.body.errors[0].should.eql('Bad Request')
+
+            done()
+          })
+      })
+    })
+
+    it('should return error if recipe body is not valid JSON', function (done) {
+      help.getBearerToken((err, token) => {
+        request(cdnUrl)
+          .post('/api/recipes')
+          .set('Content-Type', 'application/json')
+          .send('{"recipe":"foobar"')
+          .set('Authorization', 'Bearer ' + token)
+          .expect(400, (err, res) => {
+            res.body.errors[0].should.eql('Invalid JSON Syntax')
+
+            done()
+          })
       })
     })
 
@@ -107,6 +126,7 @@ describe('Recipes', function () {
           res.body.success.should.eql(false)
           res.body.errors.should.be.Array
           res.body.errors[0].error.should.eql('Property "recipe" not found in recipe')
+
           done()
         })
       })
@@ -143,6 +163,52 @@ describe('Recipes', function () {
         })
       })
     })
+
+    it('should return error if recipe already exists', function (done) {
+      help.getBearerToken((err, token) => {
+        request(cdnUrl)
+        .post('/api/recipes')
+        .send(sample)
+        .set('Authorization', 'Bearer ' + token)
+        .end(function (err, res) {
+          res.statusCode.should.eql(201)
+
+          setTimeout(() => {
+            request(cdnUrl)
+            .post('/api/recipes')
+            .send(sample)
+            .set('Authorization', 'Bearer ' + token)
+            .end(function (err, res) {
+              res.statusCode.should.eql(400)
+              res.body.errors[0].should.eql(`Route ${sample.recipe} already exists`)
+
+              done()
+            })            
+          }, 300)
+        })
+      })
+    })
+
+    it('should return error if recipe save fails', function (done) {
+      let mockWriteJson = sinon.stub(fs, 'writeJson').rejects(
+        new Error()
+      )
+
+      help.getBearerToken((err, token) => {
+        request(cdnUrl)
+        .post('/api/recipes')
+        .send(sample)
+        .set('Authorization', 'Bearer ' + token)
+        .end(function (err, res) {
+          res.statusCode.should.eql(400)
+          res.body.errors[0].should.eql('Error when saving recipe')
+
+          mockWriteJson.restore()
+
+          done()
+        })
+      })
+    })    
 
     it('should set the correct recipe filepath', function (done) {
       help.getBearerToken((err, token) => {

--- a/test/assets/test-es6.js
+++ b/test/assets/test-es6.js
@@ -1,3 +1,3 @@
 const makeFoo = bar => {
-  return `I foo, you ${bar}`
-}
+  return `I foo, you ${bar}`;
+};

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,4 @@
+--bail
 --ui bdd
 --recursive
 --require=env-test

--- a/test/unit/jshandler.js
+++ b/test/unit/jshandler.js
@@ -86,7 +86,7 @@ describe('JS handler', function () {
       const jsHandler = new JSHandler('.js', mockRequest('/js/0/foo.js'))
 
       return jsHandler.get().then(readStream).then(out => {
-        mockCacheGet.getCall(0).args[0].should.eql('/foo.js')
+        mockCacheGet.getCall(0).args[0].includes('/foo.js').should.eql(true)
 
         out.should.eql(mockJsFile)
       })
@@ -104,7 +104,7 @@ describe('JS handler', function () {
       const jsHandler = new JSHandler('.js', mockRequest('/js/1/foo.js'))
 
       return jsHandler.get().then(readStream).then(out => {
-        mockCacheGet.getCall(0).args[0].should.eql('/foo.js')
+        mockCacheGet.getCall(0).args[0].includes('/foo.js').should.eql(true)
 
         out.should.eql('const greeter=(a)=>`Hello, ${a}`;')
       })
@@ -123,7 +123,7 @@ describe('JS handler', function () {
     const jsHandler = new JSHandler('.js', mockRequest('/foo.js'))
 
     return jsHandler.get().then(readStream).then(out => {
-      mockCacheGet.getCall(0).args[0].should.eql('/foo.js')
+      mockCacheGet.getCall(0).args[0].includes('/foo.js').should.eql(true)
 
       out.should.eql(mockJsFile)
     })
@@ -141,7 +141,7 @@ describe('JS handler', function () {
     const jsHandler = new JSHandler('.js', mockRequest('/foo.js?compress=1'))
 
     return jsHandler.get().then(readStream).then(out => {
-      mockCacheGet.getCall(0).args[0].should.eql('/foo.js?compress=1')
+      mockCacheGet.getCall(0).args[0].includes('/foo.js?compress=1').should.eql(true)
 
       out.should.eql('const greeter=(a)=>`Hello, ${a}`;')
     })


### PR DESCRIPTION
- [x] `notFound.statusCode`
- [x] `notFound.images.enabled`
- [x] `notFound.images.path`
- [x] `images.remote.enabled`
- [x] `images.remote.path`
- [x] `images.remote.allowFullURL`
- [x] `assets.remote.enabled`
- [x] `assets.remote.path`
- [x] `caching.expireAt`
- [x] `caching.ttl`
- [x] `auth.clientId`
- [x] `auth.secret`
- [x] `auth.privateKey`
- [x] `auth.tokenTtl`
- [x] `headers.useGzipCompression`
- [x] `headers.cacheControl`
- [x] `experimental.jsTranspiling`

In addition to making the above properties overridable at domain level, this PR also includes:

- Fix an issue where the fallback image configured in `notFound.images.path` was delivered with the content-type matching the mime type of original request, not from the fallback image itself
- Make test suite bail after first failure
- Reset test configuration before tests begin by deleting `config.test.json` each time

Closes #322.