### PR TITLE
Remove reliance on wget

### DIFF
--- a/config.js
+++ b/config.js
@@ -615,6 +615,14 @@ const schema = {
       format: Boolean,
       default: false
     }
+  },
+  http: {
+    followRedirects: {
+      doc: 'The number of redirects to follow when retrieving assets via HTTP requests',
+      format: Number,
+      default: 10,
+      allowDomainOverride: true
+    }
   }
 }
 

--- a/config.js
+++ b/config.js
@@ -100,27 +100,27 @@ const schema = {
         format: Boolean,
         default: true
       }
-    }
-  },
-  aws: {
-    accessKeyId: {
-      doc: '',
-      format: String,
-      default: '',
-      env: 'AWS_ACCESS_KEY'
     },
-    secretAccessKey: {
-      doc: '',
-      format: String,
-      default: '',
-      env: 'AWS_SECRET_KEY'
-    },
-    region: {
-      doc: '',
-      format: String,
-      default: '',
-      env: 'AWS_REGION'
-    }
+    aws: {
+      accessKeyId: {
+        doc: 'Access key ID for AWS logging',
+        format: String,
+        default: '',
+        env: 'AWS_ACCESS_KEY'
+      },
+      secretAccessKey: {
+        doc: 'Secret access key for AWS logging',
+        format: String,
+        default: '',
+        env: 'AWS_SECRET_KEY'
+      },
+      region: {
+        doc: 'Region for AWS logging',
+        format: String,
+        default: '',
+        env: 'AWS_REGION'
+      }
+    }    
   },
   notFound: {
     statusCode: {
@@ -225,7 +225,7 @@ const schema = {
         allowDomainOverride: true
       },
       path: {
-        doc: '',
+        doc: 'The remote host to request images from, for example http://media.example.com',
         format: String,
         default: './public'
       }
@@ -289,7 +289,7 @@ const schema = {
       allowDomainOverride: true
     },
     ttl: {
-      doc: '',
+      doc: 'Amount of time, in seconds, after which cached items should expire',
       format: Number,
       default: 3600,
       allowDomainOverride: true
@@ -369,38 +369,38 @@ const schema = {
   },
   security: {
     maxWidth: {
-      doc: '',
+      doc: 'The maximum width, in pixels, for an output image',
       format: Number,
       default: 2048
     },
     maxHeight: {
-      doc: '',
+      doc: 'The maximum height, in pixels, for an output image',
       format: Number,
       default: 1024
     }
   },
   auth: {
     tokenUrl: {
-      doc: '',
+      doc: 'Endpoint for requesting bearer tokens',
       format: String,
       default: '/token'
     },
     clientId: {
-      doc: '',
+      doc: 'Client ID used to access protected endpoints',
       format: String,
       default: '1235488',
       env: 'AUTH_TOKEN_ID',
       allowDomainOverride: true
     },
     secret: {
-      doc: '',
+      doc: 'Client secret used to access protected endpoints',
       format: String,
       default: 'asd544see68e52',
       env: 'AUTH_TOKEN_SECRET',
       allowDomainOverride: true
     },
     tokenTtl: {
-      doc: '',
+      doc: 'Lifetime of bearer tokens (in seconds)',
       format: Number,
       default: 1800,
       env: 'AUTH_TOKEN_TTL',
@@ -409,30 +409,31 @@ const schema = {
     privateKey: {
       doc: 'Private key for signing JSON Web Tokens',
       format: String,
+      env: 'AUTH_KEY',
       default: 'YOU-MUST-CHANGE-ME-NOW!',
       allowDomainOverride: true
     }
   },
   cloudfront: {
     enabled: {
-      doc: '',
+      doc: 'Enable Amazon CloudFront',
       format: Boolean,
       default: false
     },
     accessKey: {
-      doc: '',
+      doc: 'CloudFront access key',
       format: String,
       default: '',
       env: 'CLOUDFRONT_ACCESS_KEY'
     },
     secretKey: {
-      doc: '',
+      doc: 'CloudFront secret key',
       format: String,
       default: '',
       env: 'CLOUDFRONT_SECRET_KEY'
     },
     distribution: {
-      doc: '',
+      doc: 'Name of the CloudFront distribution to use',
       format: String,
       default: '',
       env: 'CLOUDFRONT_DISTRIBUTION'
@@ -465,7 +466,7 @@ const schema = {
   },
   headers: {
     useGzipCompression: {
-      doc: "If true, uses gzip compression and adds a 'Content-Encoding:gzip' header to the response.",
+      doc: 'If true, uses gzip compression and adds a \'Content-Encoding:gzip\' header to the response.',
       format: Boolean,
       default: true,
       allowDomainOverride: true
@@ -484,11 +485,6 @@ const schema = {
       },
       allowDomainOverride: true
     }
-  },
-  feedback: {
-    doc: '',
-    format: Boolean,
-    default: false
   },
   robots: {
     doc: 'The path to a robots.txt file',

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -16,7 +16,7 @@ const RecipeController = require(path.join(__dirname, '/recipe'))
 const RouteController = require(path.join(__dirname, '/route'))
 const workspace = require(path.join(__dirname, '/../models/workspace'))
 
-logger.init(config.get('logging'), config.get('aws'), config.get('env'))
+logger.init(config.get('logging'), config.get('logging.aws'), config.get('env'))
 
 const Controller = function (router) {
   router.use(logger.requestLogger)

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -33,6 +33,12 @@ mkdirp(exifDirectory, (err, made) => {
   }
 })
 
+mkdirp(tmpDirectory, (err, made) => {
+  if (err) {
+    console.log(err)
+  }
+})
+
 const GRAVITY_TYPES = {
   NW: 'northwest',
   N: 'north',

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -12,11 +12,18 @@ module.exports.clearCache = function (pathname, callback) {
 module.exports.sendBackJSON = function (successCode, results, res) {
   res.statusCode = successCode
 
-  let resBody = JSON.stringify(results)
+  let resBody
 
-  if (results instanceof Error && resBody === '{}') {
-    resBody = JSON.stringify({ message: results.message || 'unknown error' })
-    res.statusCode = results.statusCode || res.statusCode
+  if (results instanceof Error) {
+    res.statusCode = results.statusCode || successCode || 500
+
+    resBody = JSON.stringify({
+      message: results.message || 'unknown error',
+      statusCode: res.statusCode,
+      success: false
+    })
+  } else {
+    resBody = JSON.stringify(results)
   }
 
   res.setHeader('Content-Type', 'application/json')

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -67,11 +67,17 @@ HTTPStorage.prototype.get = function ({
         [301, 302, 307].includes(res.statusCode) &&
         typeof res.headers.location === 'string'
       ) {
+        let parsedRedirectUrl = url.parse(res.headers.location)
+
+        parsedRedirectUrl.host = parsedRedirectUrl.host || parsedUrl.host
+        parsedRedirectUrl.port = parsedRedirectUrl.port || parsedUrl.port
+        parsedRedirectUrl.protocol = parsedRedirectUrl.protocol || parsedUrl.protocol
+
         if (redirects < config.get('http.followRedirects', this.domain)) {
           return resolve(
             this.get({
               redirects: redirects + 1,
-              requestUrl: res.headers.location
+              requestUrl: url.format(parsedRedirectUrl)
             })
           )
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/cdn",
-  "version": "3.0.0-rc1",
+  "version": "3.0.0-rc3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4269,6 +4269,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4277,14 +4285,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4462,6 +4462,15 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
         "assert-plus": "1.0.0"
+      }
+    },
+    "gifwrap": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.7.5.tgz",
+      "integrity": "sha1-3sf07ld8gtcN5OtLQYwE3o9F5ic=",
+      "requires": {
+        "image-q": "1.1.1",
+        "omggif": "1.0.9"
       }
     },
     "github-from-package": {
@@ -4874,6 +4883,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
+    },
+    "image-q": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-1.1.1.tgz",
+      "integrity": "sha1-/IQJlmRGC5DKhi2TALa/u7+/gFY="
     },
     "image-size": {
       "version": "0.6.2",
@@ -6646,6 +6660,11 @@
         }
       }
     },
+    "omggif": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
+      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -6664,7 +6683,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -8212,6 +8231,14 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -8220,14 +8247,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,22 +74,6 @@
         }
       }
     },
-    "@dadi/wget": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@dadi/wget/-/wget-1.4.2.tgz",
-      "integrity": "sha512-rxuLuGpke1yiZQQfqq4JkAJFjmelQxMrc9ZHitl6CKf+XeqX59uVtTL8bHpdnjTYaG6EunEd5ezdAQ/iMyaTbg==",
-      "requires": {
-        "minimist": "1.2.0",
-        "tunnel": "0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "@greenkeeper/flags": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@greenkeeper/flags/-/flags-3.0.1.tgz",
@@ -7201,7 +7185,7 @@
     },
     "readable-stream": {
       "version": "https://github.com/jeffbski/readable-stream/archive/v1.0.2-object-transform2-ret-self.tar.gz",
-      "integrity": "sha512-4DfqsAX+1OToUZ/uHLsC3NUHN7wCn2BNfkG/Eyr2ii4c4suSipjLFbVymS7pj49+aRcSutnK9dIuHS3X7fwApQ=="
+      "integrity": "sha1-Ep5VOncxhmMui1iTnFjm9gdUK2M="
     },
     "readdirp": {
       "version": "2.1.0",
@@ -8574,11 +8558,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
-    },
-    "tunnel": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.2.tgz",
-      "integrity": "sha1-8jvNi3p7ioZCYbIIT2b5MZM5YzQ="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@dadi/cache": "^1.5.5",
     "@dadi/logger": "latest",
     "@dadi/status": "latest",
-    "@dadi/wget": "^1.4.2",
     "accept-language-parser": "^1.2.0",
     "aspect-fit": "^1.0.2",
     "aws-sdk": "2.5.4",

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -1018,6 +1018,132 @@ describe('Controller', function () {
         })
       })
 
+      it('should retrieve image from remote URL and follow redirects', done => {
+        let server = nock('https://one.somedomain.tech')
+          .get('/images/mock/logo.png')
+          .reply(301, undefined, {
+            Location: 'https://one.somedomain.tech/images/mock/logo2.png'
+          })
+          .get('/images/mock/logo2.png')
+          .reply(302, undefined, {
+            Location: 'https://one.somedomain.tech/images/mock/logo3.png'
+          })
+          .get('/images/mock/logo3.png')
+          .replyWithFile(200, 'test/images/visual/measure1.png', {
+            'Content-Type': 'image/png'
+          })
+
+        config.set('images.remote.path', 'https://one.somedomain.tech')
+
+        request(cdnUrl)
+          .get('/images/mock/logo.png')
+          .expect(200)
+          .end((err, res) => {
+            res.headers['content-type'].should.eql('image/png')
+
+            server.isDone().should.eql(true)
+
+            done()
+          })
+      })
+
+      it('should return a 404 when retrieving a remote asset that includes more redirects than the ones allowed in `http.followRedirects`', done => {
+        let server = nock('https://one.somedomain.tech')
+          .get('/images/mock/logo.png')
+          .reply(301, undefined, {
+            Location: 'https://one.somedomain.tech/images/mock/logo2.png'
+          })
+          .get('/images/mock/logo2.png')
+          .reply(302, undefined, {
+            Location: 'https://one.somedomain.tech/images/mock/logo3.png'
+          })
+          .get('/images/mock/logo3.png')
+          .replyWithFile(200, 'test/images/visual/measure1.png', {
+            'Content-Type': 'image/png'
+          })
+
+        config.set('images.remote.path', 'https://one.somedomain.tech')
+        config.set('http.followRedirects', 1)
+
+        request(cdnUrl)
+          .get('/images/mock/logo.png')
+          .expect(404)
+          .end((err, res) => {
+            server.pendingMocks().length.should.eql(1)
+
+            config.set('http.followRedirects', configBackup.http.followRedirects)
+
+            done()
+          })
+      })
+
+      it('should return a 404 when retrieving a remote asset that includes more redirects than the ones allowed in `http.followRedirects` at domain level', done => {
+        let server1 = nock('https://one.somedomain.tech')
+          .get('/images/mock/logo.png')
+          .reply(301, undefined, {
+            Location: 'https://one.somedomain.tech/images/mock/logo2.png'
+          })
+          .get('/images/mock/logo2.png')
+          .reply(302, undefined, {
+            Location: 'https://one.somedomain.tech/images/mock/logo3.png'
+          })
+          .get('/images/mock/logo3.png')
+          .replyWithFile(200, 'test/images/visual/measure1.png', {
+            'Content-Type': 'image/png'
+          })
+
+        let server2 = nock('https://two.somedomain.tech')
+          .get('/images/mock/logo.png')
+          .reply(301, undefined, {
+            Location: 'https://two.somedomain.tech/images/mock/logo2.png'
+          })
+          .get('/images/mock/logo2.png')
+          .reply(302, undefined, {
+            Location: 'https://two.somedomain.tech/images/mock/logo3.png'
+          })
+          .get('/images/mock/logo3.png')
+          .replyWithFile(200, 'test/images/visual/measure1.png', {
+            'Content-Type': 'image/png'
+          })
+
+        config.set('multiDomain.enabled', true)
+        config.loadDomainConfigs()
+
+        config.set('images.directory.enabled', false, 'localhost')
+        config.set('images.remote.enabled', true, 'localhost')
+        config.set('images.remote.path', 'https://one.somedomain.tech', 'localhost')
+        config.set('http.followRedirects', 1, 'localhost')
+
+        config.set('images.directory.enabled', false, 'testdomain.com')
+        config.set('images.remote.enabled', true, 'testdomain.com')
+        config.set('images.remote.path', 'https://two.somedomain.tech', 'testdomain.com')
+        config.set('http.followRedirects', 10, 'testdomain.com')
+
+        request(cdnUrl)
+          .get('/images/mock/logo.png')
+          .set('Host', 'localhost:80')
+          .expect(404)
+          .end((err, res) => {
+            res.body.statusCode.should.eql(404)
+
+            server1.pendingMocks().length.should.eql(1)
+
+            request(cdnUrl)
+              .get('/images/mock/logo.png')
+              .set('Host', 'testdomain.com:80')
+              .expect(200)
+              .end((err, res) => {
+                res.headers['content-type'].should.eql('image/png')
+
+                server2.isDone().should.eql(true)
+
+                config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
+
+                done()
+              })
+          })
+      })
+
       it('should return 400 when requesting a relative remote URL and `image.remote.path` is not set', done => {
         config.set('images.remote.path', null)
 

--- a/test/acceptance/recipes.js
+++ b/test/acceptance/recipes.js
@@ -641,6 +641,8 @@ describe('Recipes (with multi-domain)', () => {
     config.set('multiDomain.enabled', true)
     config.set('multiDomain.directory', 'domains')
 
+    config.loadDomainConfigs()
+
     app.start(err => {
       if (err) return done(err)
 

--- a/test/acceptance/visual.js
+++ b/test/acceptance/visual.js
@@ -43,7 +43,6 @@ describe('Visual Regression', function (done) {
       next()
     })
     .catch(err => {
-      console.log('----> ERR 1:', err)
       next(err)
     })
   })
@@ -77,11 +76,9 @@ function requestTestImage (test) {
               return reject(error)
             }
           }).catch(err => {
-            console.log('----> ERR 2:', err)
             console.error(err)
           })
       }).catch(err => {
-        console.log('----> ERR 3:', err)
         console.error(err)
       })
   })

--- a/test/acceptance/visual.js
+++ b/test/acceptance/visual.js
@@ -43,6 +43,7 @@ describe('Visual Regression', function (done) {
       next()
     })
     .catch(err => {
+      console.log('----> ERR 1:', err)
       next(err)
     })
   })
@@ -76,9 +77,11 @@ function requestTestImage (test) {
               return reject(error)
             }
           }).catch(err => {
+            console.log('----> ERR 2:', err)
             console.error(err)
           })
       }).catch(err => {
+        console.log('----> ERR 3:', err)
         console.error(err)
       })
   })


### PR DESCRIPTION
With this PR, the HTTP storage handler uses the native `http`/`https` Node modules instead of `wget`. In practice, this means that HTTP responses can be treated as streams, avoiding the creation of temporary files.