### PR TITLE
Update 404 caching logic

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -61,7 +61,7 @@ const Controller = function (router) {
           res.setHeader('Content-Length', contentLength)
           res.setHeader('ETag', etag(buffer))
 
-          if (req.headers['if-none-match'] === etag(buffer) && handler.contentType() !== 'application/json') {
+          if (req.headers['if-none-match'] === etag(buffer) && handler.getContentType() !== 'application/json') {
             res.statusCode = 304
             res.end()
           } else {
@@ -81,7 +81,7 @@ const Controller = function (router) {
 
         if (
           config.get('headers.useGzipCompression', req.__domain) &&
-          handler.contentType() !== 'application/json'
+          handler.getContentType() !== 'application/json'
         ) {
           res.setHeader('Content-Encoding', 'gzip')
 
@@ -160,8 +160,8 @@ const Controller = function (router) {
 }
 
 Controller.prototype.addContentTypeHeader = function (res, handler) {
-  if (handler.contentType()) {
-    res.setHeader('Content-Type', handler.contentType())
+  if (handler.getContentType()) {
+    res.setHeader('Content-Type', handler.getContentType())
   }
 }
 

--- a/dadi/lib/handlers/css.js
+++ b/dadi/lib/handlers/css.js
@@ -46,15 +46,6 @@ const CSSHandler = function (format, req, {
 }
 
 /**
- * Returns the content type for the files handled.
- *
- * @return {String} The content type
- */
-CSSHandler.prototype.contentType = function () {
-  return 'text/css'
-}
-
-/**
  * Retrieves a file for a given URL path.
  *
  * @return {Promise} A stream with the file
@@ -83,6 +74,15 @@ CSSHandler.prototype.get = function () {
       })
     })
   })
+}
+
+/**
+ * Returns the content type for the files handled.
+ *
+ * @return {String} The content type
+ */
+CSSHandler.prototype.getContentType = function () {
+  return 'text/css'
 }
 
 /**

--- a/dadi/lib/handlers/default.js
+++ b/dadi/lib/handlers/default.js
@@ -32,15 +32,6 @@ const DefaultHandler = function (format, req, {
 }
 
 /**
- * Returns the content type for the files handled.
- *
- * @return {String} The content type
- */
-DefaultHandler.prototype.contentType = function () {
-  return mime.lookup(this.url.pathname)
-}
-
-/**
  * Retrieves a file for a given URL path.
  *
  * @return {Promise} A stream with the file
@@ -67,6 +58,15 @@ DefaultHandler.prototype.get = function () {
       })
     })
   })
+}
+
+/**
+ * Returns the content type for the files handled.
+ *
+ * @return {String} The content type
+ */
+DefaultHandler.prototype.getContentType = function () {
+  return mime.lookup(this.url.pathname)
 }
 
 /**

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -403,7 +403,7 @@ ImageHandler.prototype.get = function () {
         return responseStream
       })
     }).catch(err => {
-      if (err.statusCode && !this.isCached) {
+      if ((err.statusCode === 404) && !this.isCached) {
         let errorStream = new Readable()
 
         errorStream.push(JSON.stringify(err))

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -113,40 +113,6 @@ const ImageHandler = function (format, req, {
   }, [])
 }
 
-ImageHandler.prototype.contentType = function () {
-  if (this.options.format === 'json') {
-    return 'application/json'
-  }
-
-  let outputFormat = this.format
-
-  // If the fallback image is to be delivered, the content type
-  // will need to match its format, not the format of the original
-  // file.
-  if (
-    this.storageHandler.notFound &&
-    config.get('notFound.images.enabled', this.req.__domain)
-  ) {
-    outputFormat = path.extname(
-      config.get('notFound.images.path')
-    ).slice(1)
-  }
-
-  switch (outputFormat.toLowerCase()) {
-    case 'png':
-      return 'image/png'
-    case 'jpg':
-    case 'jpeg':
-      return 'image/jpeg'
-    case 'gif':
-      return 'image/gif'
-    case 'webp':
-      return 'image/webp'
-    default:
-      return 'image/jpeg'
-  }
-}
-
 /**
  * Convert image according to options specified
  * @param {stream} stream - read stream from S3, local disk or url
@@ -463,6 +429,44 @@ ImageHandler.prototype.getAvailablePlugins = function (files) {
 
     return plugins
   }, [])
+}
+
+ImageHandler.prototype.getContentType = function () {
+  if (this.contentType) {
+    return this.contentType
+  }
+
+  if (this.options.format === 'json') {
+    return 'application/json'
+  }
+
+  let outputFormat = this.format
+
+  // If the fallback image is to be delivered, the content type
+  // will need to match its format, not the format of the original
+  // file.
+  if (
+    this.storageHandler.notFound &&
+    config.get('notFound.images.enabled', this.req.__domain)
+  ) {
+    outputFormat = path.extname(
+      config.get('notFound.images.path')
+    ).slice(1)
+  }
+
+  switch (outputFormat.toLowerCase()) {
+    case 'png':
+      return 'image/png'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'gif':
+      return 'image/gif'
+    case 'webp':
+      return 'image/webp'
+    default:
+      return 'image/jpeg'
+  }
 }
 
 /**

--- a/dadi/lib/handlers/image.js
+++ b/dadi/lib/handlers/image.js
@@ -16,7 +16,6 @@ const Readable = require('stream').Readable
 const sha1 = require('sha1')
 const sharp = require('sharp')
 const smartcrop = require('smartcrop-sharp')
-const toString = require('stream-to-string')
 const urlParser = require('url')
 const Vibrant = require('node-vibrant')
 

--- a/dadi/lib/handlers/js.js
+++ b/dadi/lib/handlers/js.js
@@ -40,15 +40,6 @@ const JSHandler = function (format, req, {
 }
 
 /**
- * Returns the content type for the files handled.
- *
- * @return {String} The content type
- */
-JSHandler.prototype.contentType = function () {
-  return 'application/javascript'
-}
-
-/**
  * Retrieves a file for a given URL path.
  *
  * @return {Promise} A stream with the file
@@ -163,6 +154,15 @@ JSHandler.prototype.getBabelPluginsHash = function () {
   const hash = farmhash.fingerprint64(hashSource)
 
   return hash
+}
+
+/**
+ * Returns the content type for the files handled.
+ *
+ * @return {String} The content type
+ */
+JSHandler.prototype.getContentType = function () {
+  return 'application/javascript'
 }
 
 /**

--- a/dadi/lib/handlers/plugin.js
+++ b/dadi/lib/handlers/plugin.js
@@ -10,10 +10,6 @@ const Plugin = function (req, plugin) {
   this.storageFactory = Object.create(StorageFactory)
 }
 
-Plugin.prototype.contentType = function () {
-  return this.headers['content-type']
-}
-
 Plugin.prototype.get = function () {
   try {
     return Promise.resolve(
@@ -35,6 +31,10 @@ Plugin.prototype.get = function () {
 
     return Promise.reject(error)
   }
+}
+
+Plugin.prototype.getContentType = function () {
+  return this.headers['content-type']
 }
 
 Plugin.prototype.getHeader = function (header) {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "smartcrop-sharp": "^2.0.2",
     "sqwish": "^0.2.2",
     "stream-length": "^1.0.2",
-    "stream-to-string": "^1.1.0",
     "streamifier": "^0.1.1",
     "ua-parser-js": "^0.7.10",
     "uglify-js": "^3.0.25",

--- a/workspace/plugins/layout.js
+++ b/workspace/plugins/layout.js
@@ -53,20 +53,6 @@ const ImageLayoutProcessor = function ({assetStore, cache, req, setHeader}) {
   this.setHeader = setHeader
 }
 
-ImageLayoutProcessor.prototype.contentType = function () {
-  switch (this.format.toLowerCase()) {
-    case 'png':
-      return 'image/png'
-    case 'jpg':
-    case 'jpeg':
-      return 'image/jpeg'
-    case 'gif':
-      return 'image/gif'
-    default:
-      return 'image/jpeg'
-  }
-}
-
 ImageLayoutProcessor.prototype.get = function () {
   const cacheKey = this.req.url
 
@@ -166,6 +152,20 @@ ImageLayoutProcessor.prototype.get = function () {
       })
     })
   })
+}
+
+ImageLayoutProcessor.prototype.getContentType = function () {
+  switch (this.format.toLowerCase()) {
+    case 'png':
+      return 'image/png'
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg'
+    case 'gif':
+      return 'image/gif'
+    default:
+      return 'image/jpeg'
+  }
 }
 
 ImageLayoutProcessor.prototype.getImageSize = function (stream) {

--- a/workspace/plugins/layout.js
+++ b/workspace/plugins/layout.js
@@ -78,7 +78,7 @@ ImageLayoutProcessor.prototype.get = function () {
     this.format = this.fileExt
 
     // Set content type
-    this.setHeader('content-type', this.contentType())
+    this.setHeader('content-type', this.getContentType())
 
     const assetsQueue = this.inputs.map(input => {
       if (input.fileName) {


### PR DESCRIPTION
@jimlambie I have made minor changes to your implementation, so that:

- Cached streams are returned without any conversion, regardless of whether they are a normal image, a fallback image or a JSON payload
- If an error is cached, the metadata block is used to store the error code, as well as the content-type of the fallback image (if any), in case the fallback image changes and there is a mismatch
- The `X-Cache` header returns `HIT` if a 404 was retrieved from cache

Also, I renamed the `contentType` method to `getContentType`.