### PR TITLE
Override remote asset

### DIFF
--- a/config.js
+++ b/config.js
@@ -277,7 +277,8 @@ const schema = {
       path: {
         doc: 'The remote host to request assets from, for example http://media.example.com',
         format: String,
-        default: ''
+        default: '',
+        allowDomainOverride: true
       }
     }
   },

--- a/dadi/lib/handlers/css.js
+++ b/dadi/lib/handlers/css.js
@@ -63,7 +63,7 @@ CSSHandler.prototype.get = function () {
     this.storageHandler = this.storageFactory.create(
       'asset',
       this.url.pathname.slice(1),
-      false
+      {domain: this.req.__domain}
     )
 
     return this.storageHandler.get().then(stream => {

--- a/dadi/lib/handlers/default.js
+++ b/dadi/lib/handlers/default.js
@@ -49,7 +49,7 @@ DefaultHandler.prototype.get = function () {
     this.storageHandler = this.storageFactory.create(
       'asset',
       this.url.pathname.slice(1),
-      false
+      {domain: this.req.__domain}
     )
 
     return this.storageHandler.get().then(stream => {
@@ -66,6 +66,10 @@ DefaultHandler.prototype.get = function () {
  * @return {String} The content type
  */
 DefaultHandler.prototype.getContentType = function () {
+  if (path.extname(this.url.pathname) === '') {
+    return 'text/html'
+  }
+
   return mime.lookup(this.url.pathname)
 }
 

--- a/dadi/lib/handlers/js.js
+++ b/dadi/lib/handlers/js.js
@@ -61,7 +61,7 @@ JSHandler.prototype.get = function () {
     this.storageHandler = this.storageFactory.create(
       'asset',
       this.url.pathname.slice(1),
-      false
+      {domain: this.req.__domain}
     )
 
     return this.storageHandler.get().then(stream => {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -19,6 +19,17 @@ const dadiStatus = require('@dadi/status')
 const domainManager = require('./models/domain-manager')
 const workspace = require('./models/workspace')
 
+process
+  .on('unhandledRejection', (reason, p) => {
+    console.error(reason, 'Unhandled Rejection at Promise', p)
+    console.trace()
+  })
+  .on('uncaughtException', err => {
+    console.error(err, 'Uncaught Exception thrown')
+    console.trace()
+    process.exit(1)
+  })
+
 // Let's ensure there's at least a dev config file here.
 const devConfigPath = path.join(
   __dirname,
@@ -206,7 +217,7 @@ Server.prototype.start = function (done) {
     next()
   })
 
-  router.get('/', function (req, res, next) {
+  router.get('/hello', function (req, res, next) {
     res.end('Welcome to DADI CDN')
   })
 

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -217,7 +217,7 @@ Server.prototype.start = function (done) {
     next()
   })
 
-  router.get('/hello', function (req, res, next) {
+  router.get('/', function (req, res, next) {
     res.end('Welcome to DADI CDN')
   })
 

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -12,6 +12,7 @@ const Missing = require(path.join(__dirname, '/missing'))
 const HTTPStorage = function ({assetType = 'assets', domain, url}) {
   let isExternalURL = url.indexOf('http:') === 0 ||
     url.indexOf('https:') === 0
+
   let remoteAddress = config.get(`${assetType}.remote.path`, domain)
 
   if (!isExternalURL) {

--- a/domains/localhost/config/config.test.json
+++ b/domains/localhost/config/config.test.json
@@ -3,5 +3,10 @@
     "remote": {
       "path": "http://one.somedomain.tech"
     }
+  },
+  "assets": {
+    "remote": {
+      "path": "http://one.somedomain.tech"
+    }
   }
 }

--- a/domains/testdomain.com/config/config.test.json
+++ b/domains/testdomain.com/config/config.test.json
@@ -6,5 +6,10 @@
     "remote": {
       "path": "http://two.somedomain.tech"
     }
+  },
+  "assets": {
+    "remote": {
+      "path": "http://two.somedomain.tech"
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5679,17 +5679,6 @@
         }
       }
     },
-    "istanbul-cobertura-badger": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/istanbul-cobertura-badger/-/istanbul-cobertura-badger-1.3.1.tgz",
-      "integrity": "sha1-PNkMQrZSRthYmOA7TWn3tsis4zQ=",
-      "dev": true,
-      "requires": {
-        "commander": "^2.8.1",
-        "xml-splitter": "~1.2.1",
-        "xtend": "~4.0.1"
-      }
-    },
     "istanbul-lib-coverage": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
@@ -9494,30 +9483,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
       "integrity": "sha1-qQKekp09vN7RafPG4oI42VpdWig="
-    },
-    "xml-splitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/xml-splitter/-/xml-splitter-1.2.1.tgz",
-      "integrity": "sha1-s/0oyIBj5RCrajXtCUMpJAnEyBI=",
-      "dev": true,
-      "requires": {
-        "clone": "~0.1.11",
-        "sax": "~0.5.5"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.1.19",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
-          "integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=",
-          "dev": true
-        },
-        "sax": {
-          "version": "0.5.8",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
-          "dev": true
-        }
-      }
     },
     "xml2js": {
       "version": "0.4.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2632,6 +2632,27 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "coveralls": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.1.tgz",
+      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.6.1",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.5",
+        "minimist": "^1.2.0",
+        "request": "^2.79.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -6022,6 +6043,12 @@
       "dev": true,
       "optional": true
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "length-stream": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/length-stream/-/length-stream-0.1.1.tgz",
@@ -6126,6 +6153,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "greenkeeper-postpublish": "^1.0.1",
     "http-proxy": "^1.16.2",
     "istanbul": "^1.1.0-alpha.1",
-    "istanbul-cobertura-badger": "^1.2.1",
     "it-each": "^0.3.1",
     "mocha": "^5.2.0",
     "nock": "^9.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "farmhash": "2.1.0",
     "finalhandler": "~1.1.0",
     "fs-extra": "^6.0.0",
-    "fsevents": "^1.2.4",
     "gifwrap": "^0.7.5",
     "he": "^1.1.0",
     "image-size": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "farmhash": "2.1.0",
     "finalhandler": "~1.1.0",
     "fs-extra": "^6.0.0",
+    "fsevents": "^1.2.4",
     "gifwrap": "^0.7.5",
     "he": "^1.1.0",
     "image-size": "^0.6.2",
@@ -73,6 +74,7 @@
   },
   "devDependencies": {
     "aws-sdk-mock": "^1.5.0",
+    "coveralls": "^3.0.1",
     "env-test": "^1.0.0",
     "fakeredis": "^2.0.0",
     "greenkeeper-postpublish": "^1.0.1",

--- a/scripts/coverage.js
+++ b/scripts/coverage.js
@@ -1,44 +1,9 @@
 #! /usr/bin/env node
 
-var fs = require('fs')
-var path = require('path')
+const exec = require('child_process').exec
 
-var coberturaBadger = require('istanbul-cobertura-badger')
-
-var opts = {
-  badgeFileName: 'coverage',
-  destinationDir: __dirname,
-  istanbulReportFile: path.resolve(__dirname + '/../coverage', 'cobertura-coverage.xml'),
-  thresholds: {
-    excellent: 90, // overall percent >= excellent, green badge
-    good: 60 // overall percent < excellent and >= good, yellow badge
-  // overall percent < good, red badge
-  }
-}
-
-// console.log(opts)
-
-// Load the badge for the report$
-coberturaBadger(opts, function parsingResults (err, badgeStatus) {
-  if (err) {
-    console.log('An error occurred: ' + err.message)
-  }
-
-  // console.log(badgeStatus)
-
-  var readme = path.resolve(__dirname + '/../README.md')
-  var badgeUrl = badgeStatus.url // e.g. http://img.shields.io/badge/coverage-60%-yellow.svg
-
-  // open the README.md and add this url
-  fs.readFile(readme, {encoding: 'utf-8'}, function (err, body) {
-    body = body.replace(/(!\[coverage\]\()(.+?)\?*(\))/g, function (whole, a, b, c) {
-      return a + badgeUrl + c
-    })
-
-    fs.writeFile(readme, body, {encoding: 'utf-8'}, function (err) {
-      if (err) console.log(err.toString())
-
-      console.log('Coverage badge successfully added to ' + readme)
-    })
+if (process.env['CI']) {
+  exec('cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js', (err, out) => {
+    if (err) console.log(err)
   })
-})
+}

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -1599,10 +1599,10 @@ describe('Controller', function () {
     })
 
     describe('Other', function () {
-      it('should respond to the root', function (done) {
+      it('should respond to the hello endpoint', function (done) {
         var client = request(cdnUrl)
         client
-          .get('/')
+          .get('/hello')
           .end(function (err, res) {
             res.statusCode.should.eql(200)
             res.text.should.eql('Welcome to DADI CDN')

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -1599,10 +1599,10 @@ describe('Controller', function () {
     })
 
     describe('Other', function () {
-      it('should respond to the hello endpoint', function (done) {
+      it('should respond to the root endpoint', function (done) {
         var client = request(cdnUrl)
         client
-          .get('/hello')
+          .get('/')
           .end(function (err, res) {
             res.statusCode.should.eql(200)
             res.text.should.eql('Welcome to DADI CDN')

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -17,6 +17,21 @@ const images = {
   'testdomain.com': 'test/images/dog-w600.jpeg'
 }
 
+const stylesheets = {
+  'localhost': 'test/assets/test.css',
+  'testdomain.com': 'test/assets/test.css'
+}
+
+const jsFiles = {
+  'localhost': 'test/assets/test.js',
+  'testdomain.com': 'test/assets/test.js'
+}
+
+const txtFiles = {
+  'localhost': 'test/assets/test.txt',
+  'testdomain.com': 'test/assets/test.txt'
+}
+
 let configBackup = config.get()
 let server1 = nock('http://one.somedomain.tech')
   .get('/test.jpg')
@@ -36,6 +51,60 @@ let server2 = nock('http://two.somedomain.tech')
     )
   })
 
+let cssScope1 = nock('http://one.somedomain.tech')
+  .get('/test.css')
+  .times(Infinity)
+  .reply(200, (uri, requestBody) => {
+    return fs.createReadStream(
+      path.resolve(stylesheets['localhost'])
+    )
+  })
+
+let cssScope2 = nock('http://two.somedomain.tech')
+  .get('/test.css')
+  .times(Infinity)
+  .reply(200, (uri, requestBody) => {
+    return fs.createReadStream(
+      path.resolve(stylesheets['testdomain.com'])
+    )
+  })
+
+let jsScope1 = nock('http://one.somedomain.tech')
+  .get('/test.js')
+  .times(Infinity)
+  .reply(200, (uri, requestBody) => {
+    return fs.createReadStream(
+      path.resolve(jsFiles['localhost'])
+    )
+  })
+
+let jsScope2 = nock('http://two.somedomain.tech')
+  .get('/test.js')
+  .times(Infinity)
+  .reply(200, (uri, requestBody) => {
+    return fs.createReadStream(
+      path.resolve(jsFiles['testdomain.com'])
+    )
+  })
+
+let txtScope1 = nock('http://one.somedomain.tech')
+  .get('/test.txt')
+  .times(Infinity)
+  .reply(200, (uri, requestBody) => {
+    return fs.createReadStream(
+      path.resolve(txtFiles['localhost'])
+    )
+  })
+
+let txtScope2 = nock('http://two.somedomain.tech')
+  .get('/test.txt')
+  .times(Infinity)
+  .reply(200, (uri, requestBody) => {
+    return fs.createReadStream(
+      path.resolve(txtFiles['testdomain.com'])
+    )
+  })
+
 describe('Multi-domain', function () {
   describe('if multi-domain is disabled', () => {
     before(done => {
@@ -51,7 +120,7 @@ describe('Multi-domain', function () {
     })
 
     after(done => {
-      config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
+      config.set('multiDomain.enabled', false)
 
       help.proxyStop().then(() => {
         app.stop(done)  
@@ -151,6 +220,12 @@ describe('Multi-domain', function () {
       config.set('images.directory.enabled', false, 'testdomain.com')
       config.set('images.remote.enabled', true, 'testdomain.com')
 
+      config.set('assets.directory.enabled', false, 'localhost')
+      config.set('assets.remote.enabled', true, 'localhost')
+
+      config.set('assets.directory.enabled', false, 'testdomain.com')
+      config.set('assets.remote.enabled', true, 'testdomain.com')
+
       app.start(err => {
         if (err) return done(err)
 
@@ -166,6 +241,10 @@ describe('Multi-domain', function () {
       config.set('images.directory.enabled', configBackup.images.directory.enabled, 'localhost')
       config.set('images.remote.enabled', configBackup.images.remote.enabled, 'localhost')
       config.set('images.remote.path', configBackup.images.remote.path, 'localhost')
+
+      config.set('assets.directory.enabled', configBackup.assets.directory.enabled, 'localhost')
+      config.set('assets.remote.enabled', configBackup.assets.remote.enabled, 'localhost')
+      config.set('assets.remote.path', configBackup.assets.remote.path, 'localhost')
 
       config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
 
@@ -200,6 +279,54 @@ describe('Multi-domain', function () {
         return help.imagesEqual({
           base: images['testdomain.com'],
           test: `${help.proxyUrl}/test.jpg?mockdomain=testdomain.com`
+        }).then(match => {
+          match.should.eql(true)
+        })
+      })
+    }).timeout(5000)
+
+    it('should retrieve a remote CSS file from the path specified by the domain config', () => {
+      return help.filesEqual({
+        base: stylesheets['localhost'],
+        test: `${help.proxyUrl}/test.css?mockdomain=localhost`
+      }).then(match => {
+        match.should.eql(true)
+
+        return help.filesEqual({
+          base: stylesheets['testdomain.com'],
+          test: `${help.proxyUrl}/test.css?mockdomain=testdomain.com`
+        }).then(match => {
+          match.should.eql(true)
+        })
+      })
+    }).timeout(5000)
+
+    it('should retrieve a remote TXT file from the path specified by the domain config', () => {
+      return help.filesEqual({
+        base: txtFiles['localhost'],
+        test: `${help.proxyUrl}/test.txt?mockdomain=localhost`
+      }).then(match => {
+        match.should.eql(true)
+
+        return help.filesEqual({
+          base: txtFiles['testdomain.com'],
+          test: `${help.proxyUrl}/test.txt?mockdomain=testdomain.com`
+        }).then(match => {
+          match.should.eql(true)
+        })
+      })
+    }).timeout(5000)
+
+    it.skip('should retrieve a remote JS file from the path specified by the domain config', () => {
+      return help.filesEqual({
+        base: jsFiles['localhost'],
+        test: `${help.proxyUrl}/test.js?mockdomain=localhost`
+      }).then(match => {
+        match.should.eql(true)
+
+        return help.filesEqual({
+          base: jsFiles['testdomain.com'],
+          test: `${help.proxyUrl}/test.js?mockdomain=testdomain.com`
         }).then(match => {
           match.should.eql(true)
         })

--- a/test/acceptance/ssl.js
+++ b/test/acceptance/ssl.js
@@ -43,7 +43,7 @@ describe('SSL', () => {
       if (err) return done(err)
 
       client
-        .get('/hello')
+        .get('/')
         .end((err, res) => {
           if (err) throw err
           res.statusCode.should.eql(200)
@@ -63,7 +63,7 @@ describe('SSL', () => {
 
       var httpClient = request('http://' + config.get('server.host') + ':9999')
       httpClient
-        .get('/hello')
+        .get('/')
         .expect(301)
         .end((err, res) => {
           if (err) return done(err)
@@ -81,7 +81,7 @@ describe('SSL', () => {
       if (err) return done(err)
 
       secureClient
-        .get('/hello')
+        .get('/')
         .end((err, res) => {
           if (err) throw err
           res.statusCode.should.eql(200)
@@ -100,7 +100,7 @@ describe('SSL', () => {
       if (err) return done(err)
 
       secureClient
-        .get('/hello')
+        .get('/')
         .end((err, res) => {
           if (err) throw err
           res.statusCode.should.eql(200)

--- a/test/acceptance/ssl.js
+++ b/test/acceptance/ssl.js
@@ -43,7 +43,7 @@ describe('SSL', () => {
       if (err) return done(err)
 
       client
-        .get('/')
+        .get('/hello')
         .end((err, res) => {
           if (err) throw err
           res.statusCode.should.eql(200)
@@ -63,7 +63,7 @@ describe('SSL', () => {
 
       var httpClient = request('http://' + config.get('server.host') + ':9999')
       httpClient
-        .get('/')
+        .get('/hello')
         .expect(301)
         .end((err, res) => {
           if (err) return done(err)
@@ -81,7 +81,7 @@ describe('SSL', () => {
       if (err) return done(err)
 
       secureClient
-        .get('/')
+        .get('/hello')
         .end((err, res) => {
           if (err) throw err
           res.statusCode.should.eql(200)
@@ -100,7 +100,7 @@ describe('SSL', () => {
       if (err) return done(err)
 
       secureClient
-        .get('/')
+        .get('/hello')
         .end((err, res) => {
           if (err) throw err
           res.statusCode.should.eql(200)

--- a/test/assets/test.txt
+++ b/test/assets/test.txt
@@ -1,0 +1,1 @@
+An uninteresting file.

--- a/test/unit/jshandler.js
+++ b/test/unit/jshandler.js
@@ -56,6 +56,7 @@ const readStream = stream => {
 
 describe('JS handler', function () {
   let mockCacheGet
+  let mockDiskStorageGet
 
   beforeEach(() => {
     mockCacheGet = sinon.spy(Cache.Cache.prototype, 'getStream')


### PR DESCRIPTION
This PR ensures that when multi-domain is enabled, requests for assets (.css, .js, .txt, .pdf, .etc) attempt to use a value from the domain configuration rather than the main configuration, in the same manner as image requests do.