### PR TITLE
Add work queue

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -58,6 +58,10 @@ const Controller = function (router) {
       return factory.create(req).then(handler => {
         return handler.get().then(stream => {
           return { handler, stream }
+        }).catch(err => {
+          err.__handler = handler
+
+          return Promise.reject(err)
         })
       })
     }).then(({handler, stream}) => {
@@ -122,6 +126,12 @@ const Controller = function (router) {
       }
     }).catch(err => {
       logger.error({err: err})
+
+      if (err.__handler) {
+        res.setHeader('X-Cache', err.__handler.isCached ? 'HIT' : 'MISS')
+
+        delete err.__handler
+      }
 
       help.sendBackJSON(err.statusCode || 400, err, res)
     })

--- a/dadi/lib/workQueue.js
+++ b/dadi/lib/workQueue.js
@@ -1,0 +1,36 @@
+const WorkQueue = function (multiplexFn) {
+  this.multiplexFn = multiplexFn || (i => i)
+  this.jobs = {}
+}
+
+WorkQueue.prototype.run = function (key, jobFn) {
+  if (!this.jobs[key]) {
+    this.jobs[key] = {
+      fn: jobFn().then(result => {
+        let job = this.jobs[key]
+        let subscribers = job.subscribers || []
+
+        delete this.jobs[key]
+
+        subscribers.forEach(subscriber => {
+          let subscriberResult = this.multiplexFn(result)
+
+          subscriber(subscriberResult)
+        })
+      }).catch(console.log)
+    }
+  }
+
+  return this.subscribe(key)
+}
+
+WorkQueue.prototype.subscribe = function (key) {
+  return new Promise((resolve, reject) => {
+    this.jobs[key].subscribers = this.jobs[key].subscribers || []
+    this.jobs[key].subscribers.push(
+      result => resolve(result)
+    )
+  })
+}
+
+module.exports = WorkQueue

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,9 @@
       }
     },
     "@dadi/cache": {
-      "version": "github:dadi/cache#130c6aa3097e503aaabfd4a22109c54ab26a3421",
-      "from": "github:dadi/cache#feature/in-memory-cache",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dadi/cache/-/cache-3.0.0.tgz",
+      "integrity": "sha512-7boWrbt0myXVDyGA0VVAZ1d0IJAhRbPNbHqyeQ2CKnUoOQSyPscDCEUPaPbd4eskK966iv3ALuNP2GG5+4Uc+w==",
       "requires": {
         "dbc": "^3.0.0",
         "debug": "^2.6.1",
@@ -2428,9 +2429,9 @@
       }
     },
     "cluster-key-slot": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.9.tgz",
-      "integrity": "sha512-NHiq3CUXSvG7rhGaUt3/urwIl1kk8jcrW18p0oogi1noGAahjFpCE/jDvQH27/z9SWnRaodgiHnZYmbMGDcKuA=="
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz",
+      "integrity": "sha512-21O0kGmvED5OJ7ZTdqQ5lQQ+sjuez33R+d35jZKLwqUb5mqcPHUsxOSzj61+LHVtxGZd1kShbQM3MjB/gBJkVg=="
     },
     "co": {
       "version": "4.6.0",
@@ -2821,9 +2822,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
-      "integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
+      "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -6191,9 +6192,9 @@
       }
     },
     "lokijs": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.4.tgz",
-      "integrity": "sha1-RiJZXGvxdykwZjqzrVDR9im2zDA="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.5.tgz",
+      "integrity": "sha1-HCH4KvdXkDf63nueSBNIXCNwi7Y="
     },
     "lolex": {
       "version": "1.3.2",
@@ -7022,7 +7023,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,8 @@
       }
     },
     "@dadi/cache": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@dadi/cache/-/cache-2.0.1.tgz",
-      "integrity": "sha512-RP4bhHHx1iKR8N9MXMSCrT2G6zsg7HjGhWeXI1xH9j6jMFKVhabZfCgebusCe7sQC+IamJ6c4AQIMTP2/iOxDw==",
+      "version": "github:dadi/cache#130c6aa3097e503aaabfd4a22109c54ab26a3421",
+      "from": "github:dadi/cache#feature/in-memory-cache",
       "requires": {
         "dbc": "^3.0.0",
         "debug": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dadi/boot": "^1.1.4",
-    "@dadi/cache": "dadi/cache#feature/in-memory-cache",
+    "@dadi/cache": "^3.0.0",
     "@dadi/logger": "latest",
     "@dadi/status": "latest",
     "accept-language-parser": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@dadi/boot": "^1.1.4",
-    "@dadi/cache": "~2.0.0",
+    "@dadi/cache": "dadi/cache#feature/in-memory-cache",
     "@dadi/logger": "latest",
     "@dadi/status": "latest",
     "accept-language-parser": "^1.2.0",

--- a/test/acceptance/work-queue.js
+++ b/test/acceptance/work-queue.js
@@ -1,0 +1,98 @@
+const app = require('./../../dadi/lib/')
+const assert = require('assert')
+const cache = require('./../../dadi/lib/cache')
+const config = require('./../../config')
+const fs = require('fs')
+const help = require('./help')
+const ImageHandler = require('./../../dadi/lib/handlers/image').ImageHandler
+const request = require('supertest')
+const sinon = require('sinon')
+const should = require('should')
+
+let bearerToken
+let cdnUrl = `http://${config.get('server.host')}:${config.get('server.port')}`
+let client = request(cdnUrl)
+let configBackup = config.get()
+
+describe('Work queue', function () {
+  this.timeout(10000)
+
+  beforeEach(done => {
+    config.set('caching.directory.enabled', false)
+    config.set('caching.redis.enabled', false)
+    config.set('images.directory.enabled', true)
+    config.set('images.remote.enabled', false)
+
+    app.start(function () {
+      help.getBearerToken((err, token) => {
+        if (err) return done(err)
+
+        bearerToken = token
+        done()
+      })
+    })    
+  })
+
+  afterEach(done => {
+    help.clearCache()
+    app.stop(done)
+
+    config.set('caching.directory.enabled', configBackup.caching.directory.enabled)
+    config.set('caching.redis.enabled', configBackup.caching.redis.enabled)
+    config.set('images.directory.enabled', configBackup.images.directory.enabled)
+    config.set('images.remote.enabled', configBackup.images.remote.enabled)
+  })
+
+  it('should process the image just once on subsequent requests and render the correct result (5 requests)', () => {
+    let processorSpy = sinon.spy(ImageHandler.prototype, 'process')
+    let numberOfRequests = 5
+    let ops = Array.apply(null, {
+      length: numberOfRequests
+    }).map(() => {
+      return help.imagesEqual({
+        base: 'test/images/original.jpg',
+        test: `${cdnUrl}/original.jpg`
+      })
+    })
+
+    return Promise.all(ops).then(results => {
+      results.every(Boolean).should.eql(true)
+      processorSpy.callCount.should.eql(1)
+      processorSpy.restore()
+    })
+  })
+
+  it('should process the image just once on subsequent requests (200 requests)', () => {
+    let processorSpy = sinon.spy(ImageHandler.prototype, 'process')
+    let numberOfRequests = 200
+    let ops = Array.apply(null, {
+      length: numberOfRequests
+    }).map(() => {
+      return new Promise((resolve, reject) => {
+        client
+        .get('/original.jpg')
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return reject(err)
+          }
+
+          resolve(res)
+        })
+      })
+    })
+
+    return Promise.all(ops).then(results => {
+      results.every(res => {
+        res.statusCode.should.eql(200)
+        res.headers['content-type'].should.eql(
+          'image/jpeg'
+        )
+
+        return true
+      }).should.eql(true)
+      processorSpy.callCount.should.eql(1)
+      processorSpy.restore()
+    })
+  })
+})

--- a/test/acceptance/work-queue.js
+++ b/test/acceptance/work-queue.js
@@ -62,9 +62,9 @@ describe('Work queue', function () {
     })
   })
 
-  it('should process the image just once on subsequent requests (200 requests)', () => {
+  it('should process the image just once on subsequent requests (50 requests)', () => {
     let processorSpy = sinon.spy(ImageHandler.prototype, 'process')
-    let numberOfRequests = 200
+    let numberOfRequests = 50
     let ops = Array.apply(null, {
       length: numberOfRequests
     }).map(() => {


### PR DESCRIPTION
This PR adds a work queue to ensure that if multiple requests come in for the same resource before the first one has finished processing (i.e. get the item from cache or manipulate it on-demand), the other requests wait for the result of the first one instead of requesting a new computation each time. When the processing for the first request finishes, all waiting requests are served and the request is removed from the work queue.

This PR is work in progress. CI tests are failing because the branch is using an unpublished version of `@dadi/cache`.