### PR TITLE
Receive full response from HTTP GET request

### DIFF
--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -3,8 +3,8 @@
 const config = require('./../../../config')
 const http = require('http')
 const https = require('https')
-const PassThrough = require('stream').PassThrough
 const path = require('path')
+const streamifier = require('streamifier')
 const url = require('url')
 const urljoin = require('url-join')
 const Missing = require(path.join(__dirname, '/missing'))
@@ -39,8 +39,6 @@ HTTPStorage.prototype.get = function ({
   redirects = 0,
   requestUrl = this.getFullUrl()
 } = {}) {
-  let outputStream = PassThrough()
-
   return new Promise((resolve, reject) => {
     let parsedUrl = url.parse(requestUrl)
     let requestFn = parsedUrl.protocol === 'https:'
@@ -56,72 +54,78 @@ HTTPStorage.prototype.get = function ({
         'User-Agent': 'DADI CDN'
       }
     }, res => {
-      if (res.statusCode === 200) {
-        res.pipe(outputStream)
-
-        return resolve(outputStream)
-      }
-
       let statusCode = res.statusCode
 
-      if (
-        [301, 302, 307].includes(res.statusCode) &&
-        typeof res.headers.location === 'string'
-      ) {
-        let parsedRedirectUrl = url.parse(res.headers.location)
+      if (statusCode === 200) {
+        let buffers = []
 
-        parsedRedirectUrl.host = parsedRedirectUrl.host || parsedUrl.host
-        parsedRedirectUrl.port = parsedRedirectUrl.port || parsedUrl.port
-        parsedRedirectUrl.protocol = parsedRedirectUrl.protocol || parsedUrl.protocol
+        res.on('data', chunk => {
+          buffers.push(chunk)
+        })
 
-        if (redirects < config.get('http.followRedirects', this.domain)) {
-          return resolve(
-            this.get({
-              redirects: redirects + 1,
-              requestUrl: url.format(parsedRedirectUrl)
-            })
-          )
-        }
-
-        // We've hit the maximum number of redirects allowed, so we'll
-        // treat this as a 404.
-        statusCode = 404
-      }
-
-      let httpError
-
-      switch (statusCode) {
-        case 404:
-          httpError = new Error(`Not Found: ${this.getFullUrl()}`)
-
-          break
-
-        case 403:
-          httpError = new Error(`Forbidden: ${this.getFullUrl()}`)
-
-          break
-
-        default:
-          httpError = new Error(`Remote server responded with error code ${statusCode} for URL: ${this.getFullUrl()}`)
-
-          break
-      }
-
-      httpError.statusCode = statusCode
-
-      if (statusCode === 404) {
-        new Missing().get({
-          domain: this.domain
-        }).then(stream => {
-          this.notFound = true
-          this.lastModified = new Date()
-
-          resolve(stream)
-        }).catch(() => {
-          reject(httpError)
+        res.on('end', () => {
+          return resolve(streamifier.createReadStream(Buffer.concat(buffers)))
         })
       } else {
-        reject(httpError)
+        if (
+          [301, 302, 307].includes(statusCode) &&
+          typeof res.headers.location === 'string'
+        ) {
+          let parsedRedirectUrl = url.parse(res.headers.location)
+
+          parsedRedirectUrl.host = parsedRedirectUrl.host || parsedUrl.host
+          parsedRedirectUrl.port = parsedRedirectUrl.port || parsedUrl.port
+          parsedRedirectUrl.protocol = parsedRedirectUrl.protocol || parsedUrl.protocol
+
+          if (redirects < config.get('http.followRedirects', this.domain)) {
+            return resolve(
+              this.get({
+                redirects: redirects + 1,
+                requestUrl: url.format(parsedRedirectUrl)
+              })
+            )
+          }
+
+          // We've hit the maximum number of redirects allowed, so we'll
+          // treat this as a 404.
+          statusCode = 404
+        }
+
+        let httpError
+
+        switch (statusCode) {
+          case 404:
+            httpError = new Error(`Not Found: ${this.getFullUrl()}`)
+
+            break
+
+          case 403:
+            httpError = new Error(`Forbidden: ${this.getFullUrl()}`)
+
+            break
+
+          default:
+            httpError = new Error(`Remote server responded with error code ${statusCode} for URL: ${this.getFullUrl()}`)
+
+            break
+        }
+
+        httpError.statusCode = statusCode
+
+        if (statusCode === 404) {
+          new Missing().get({
+            domain: this.domain
+          }).then(stream => {
+            this.notFound = true
+            this.lastModified = new Date()
+
+            resolve(stream)
+          }).catch(() => {
+            reject(httpError)
+          })
+        } else {
+          reject(httpError)
+        }
       }
     })
   })


### PR DESCRIPTION
This PR modifies the remote storage provider, collecting all chunks from the response into a buffer before re-streaming the buffer to pass to the calling function.

This is a temporary solution to the "hangs when requesting super large file" issue seen in some installs. An investigation is ongoing to determine if we can use streams throughout the process without having to convert between buffers and streams.