### PR TITLE
Add branch name check to precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "fs-extra": "^6.0.0",
     "gifwrap": "^0.7.5",
     "he": "^1.1.0",
+    "husky": "^0.14.3",
     "image-size-stream": "1.1.0",
     "images": "^3.0.0",
     "jimp": "^0.2.28",
@@ -62,6 +63,7 @@
     "sharp": "^0.20.7",
     "simple-bufferstream": "^1.0.0",
     "smartcrop-sharp": "^2.0.2",
+    "snyk": "^1.93.0",
     "sqwish": "^0.2.2",
     "stream-length": "^1.0.2",
     "streamifier": "^0.1.1",
@@ -71,8 +73,7 @@
     "url-join": "^3.0.0",
     "useragent": "2.3.0",
     "uuid": "latest",
-    "validate-commit-message": "^3.0.1",
-    "snyk": "^1.93.0"
+    "validate-commit-message": "^3.0.1"
   },
   "devDependencies": {
     "aws-sdk-mock": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "init": "validate-commit-msg",
     "start": "node index.js --node_env=development",
     "test": "rm -f config/config.test.json && standard 'dadi/**/*.js' && env NODE_ENV=test ./node_modules/.bin/istanbul cover -x '**/workspace/**' --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha test",
+    "precommit": "node scripts/precommit.js",
     "posttest": "./scripts/coverage.js",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"

--- a/scripts/precommit.js
+++ b/scripts/precommit.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const exec = require('child_process').exec
+
+function currentBranch () {
+  return new Promise((resolve, reject) => {
+    exec('git branch --no-color', (err, out) => {
+      if (err) return reject(err)
+
+      let branches = out.split('\n')
+      let branch = branches.find(branch => {
+        return /^\*/.test(branch)
+      })
+
+      branch = branch.replace('*', '')
+      branch = branch.trim()
+
+      return resolve(branch)
+    })
+  })
+}
+
+currentBranch().then(branch => {
+  console.log('Checking valid branch name...')
+
+  if (branch !== 'master' &&
+    branch !== 'develop' &&
+    !/^feature\//.test(branch) &&
+    !/^patch\//.test(branch) &&
+    !/^release-/.test(branch)
+  ) {
+    console.log()
+    console.log('Branch name invalid.')
+    console.log('Please use topic branches named "feature/...", or "patch/..."')
+    console.log()
+
+    process.exit(1)
+  } else {
+    console.log('Branch name OK.')
+    process.exit(0)
+  }
+})


### PR DESCRIPTION
This PR introduces a script to be run as a precommit hook to ensure the current branch name matches one of the allowed feature/patch/release/develop/master