### PR TITLE
Don't assume jpg when no extension exists

### DIFF
--- a/dadi/lib/handlers/factory.js
+++ b/dadi/lib/handlers/factory.js
@@ -23,9 +23,9 @@ function getFormat (req) {
   let parsedPath = parseUrl(req).pathname
 
   // add default jpg extension
-  if (path.extname(parsedPath) === '') {
-    parsedPath += '.jpg'
-  }
+  // if (path.extname(parsedPath) === '') {
+  //   parsedPath += '.jpg'
+  // }
 
   if (req.__cdnLegacyURLSyntax) {
     return parsedPath.split('/').find(Boolean)


### PR DESCRIPTION
In previous builds we used JPG as a default when no extension was given. We can no longer assume this is the case, and it has simply been disabled. 

_This must be revisited. Perhaps we should be retrieving the resource first and parsing the response's content type before we can determine which of the asset handlers should be invoked. However this requires a rethink of the image/asset split._

cc @eduardoboucas 