### PR TITLE
Add publicUrl config

### DIFF
--- a/config.js
+++ b/config.js
@@ -78,7 +78,7 @@ const schema = {
     port: {
       doc: 'The port of the URL where the CDN instance can be publicly accessed at',
       format: '*',
-      default: null,
+      default: 80,
       env: 'URL_PORT'
     },
     protocol: {

--- a/config.js
+++ b/config.js
@@ -68,6 +68,26 @@ const schema = {
       env: 'SSL_INTERMEDIATE_CERTIFICATE_PATHS'
     }
   },
+  publicUrl: {
+    host: {
+      doc: 'The host of the URL where the CDN instance can be publicly accessed at',
+      format: '*',
+      default: null,
+      env: 'URL_HOST'
+    },
+    port: {
+      doc: 'The port of the URL where the CDN instance can be publicly accessed at',
+      format: '*',
+      default: null,
+      env: 'URL_PORT'
+    },
+    protocol: {
+      doc: 'The protocol of the URL where the CDN instance can be publicly accessed at',
+      format: 'String',
+      default: 'http',
+      env: 'URL_PROTOCOL'
+    }
+  },
   logging: {
     enabled: {
       doc: 'If true, logging is enabled using the following settings.',

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -365,13 +365,17 @@ Server.prototype.status = function (req, res, next) {
     return next()
   }
 
+  let baseUrl = config.get('publicUrl') && config.get('publicUrl.host')
+    ? `${config.get('publicUrl.protocol')}://${config.get('publicUrl.host')}:${config.get('publicUrl.port')}`
+    : `http://${config.get('server.host')}:${config.get('server.port')}`
+
   let params = {
     site: site,
     package: '@dadi/cdn',
     version: version,
     healthCheck: {
       authorization: authorization,
-      baseUrl: `http://${config.get('server.host')}:${config.get('server.port')}`,
+      baseUrl: baseUrl,
       routes: config.get('status.routes')
     }
   }


### PR DESCRIPTION
This PR adds a config option for publicUrl to match other products and also uses it as the base URL when doing status checks against hosted images.

Close #447 