### PR TITLE
Add domain config endpoints

### DIFF
--- a/config.js
+++ b/config.js
@@ -614,6 +614,13 @@ const schema = {
       allowDomainOverride: true
     }
   },
+  dadiNetwork: {
+    enableConfigurationAPI: {
+      doc: 'Whether to enable domain configuration endpoints',
+      format: Boolean,
+      default: false
+    }
+  },
   multiDomain: {
     directory: {
       doc: 'Path to domains directory',

--- a/config.js
+++ b/config.js
@@ -748,6 +748,11 @@ Config.prototype.get = function (path, domain) {
   return this.domainConfigs[domain].get(path)
 }
 
+Config.prototype.loadDomainConfig = function (domain, domainConfig) {
+  this.domainConfigs[domain] = convict(this.domainSchema)
+  this.domainConfigs[domain].load(domainConfig)
+}
+
 /**
  * Builds a hash map with a Convict instance for each configured
  * domain.

--- a/dadi/lib/controller/domain.js
+++ b/dadi/lib/controller/domain.js
@@ -16,7 +16,7 @@ module.exports.post = (req, res) => {
 
   let domains = req.body
 
-  domains.forEach((item, index) => {
+  domains.forEach(item => {
     if (!DomainManager.getDomain(item.domain)) {
       // Prepare the domain configuration.
       let configContent = {
@@ -43,14 +43,12 @@ module.exports.post = (req, res) => {
       // Add the domain configuration.
       DomainManager.addDomain(item.domain, configContent)
     }
-
-    if (index === domains.length - 1) {
-      return help.sendBackJSON(201, {
-        success: true,
-        domains: DomainManager.getDomains().map(item => item.domain)
-      }, res)
-    }
   })
+
+  return help.sendBackJSON(201, {
+    success: true,
+    domains: DomainManager.getDomains().map(item => item.domain)
+  }, res)
 }
 
 /**
@@ -61,7 +59,7 @@ module.exports.put = (req, res) => {
   let payload = req.body
 
   // Don't accept an empty param.
-  if (!domain || !Object.keys(payload).length === 0) {
+  if (!domain || Object.keys(payload).length === 0) {
     return help.sendBackJSON(400, {
       success: false,
       errors: ['Bad Request']

--- a/dadi/lib/controller/domain.js
+++ b/dadi/lib/controller/domain.js
@@ -2,26 +2,6 @@ const path = require('path')
 const DomainManager = require(path.join(__dirname, '/../models/domain-manager'))
 const help = require(path.join(__dirname, '/../help'))
 
-const configTemplate = {
-  images: {
-    directory: {
-      enabled: false
-    },
-    remote: {
-      enabled: true,
-      path: null
-    }
-  },
-  assets: {
-    directory: {
-      enabled: false
-    },
-    remote: {
-      enabled: true,
-      path: null
-    }
-  }
-}
 /**
  * Accept POST requests for adding domains to the internal domain configuration.
  */
@@ -39,9 +19,26 @@ module.exports.post = (req, res) => {
   domains.forEach((item, index) => {
     if (!DomainManager.getDomain(item.domain)) {
       // Prepare the domain configuration.
-      let configContent = Object.assign({}, configTemplate)
-      configContent.images.remote.path = item.data.remote.path
-      configContent.assets.remote.path = item.data.remote.path
+      let configContent = {
+        images: {
+          directory: {
+            enabled: false
+          },
+          remote: {
+            enabled: true,
+            path: item.data.remote.path
+          }
+        },
+        assets: {
+          directory: {
+            enabled: false
+          },
+          remote: {
+            enabled: true,
+            path: item.data.remote.path
+          }
+        }
+      }
 
       // Add the domain configuration.
       DomainManager.addDomain(item.domain, configContent)
@@ -80,9 +77,26 @@ module.exports.put = (req, res) => {
   }
 
   // Prepare the domain configuration.
-  let configContent = Object.assign({}, configTemplate)
-  configContent.images.remote.path = payload.remote.path
-  configContent.assets.remote.path = payload.remote.path
+  let configContent = {
+    images: {
+      directory: {
+        enabled: false
+      },
+      remote: {
+        enabled: true,
+        path: payload.remote.path
+      }
+    },
+    assets: {
+      directory: {
+        enabled: false
+      },
+      remote: {
+        enabled: true,
+        path: payload.remote.path
+      }
+    }
+  }
 
   // Update the domain configuration.
   DomainManager.addDomain(domain, configContent)

--- a/dadi/lib/controller/domain.js
+++ b/dadi/lib/controller/domain.js
@@ -1,0 +1,118 @@
+const path = require('path')
+const DomainManager = require(path.join(__dirname, '/../models/domain-manager'))
+const help = require(path.join(__dirname, '/../help'))
+
+// Domain configuration template.
+let configContent = {
+  images: {
+    remote: {
+      path: null
+    }
+  },
+  assets: {
+    remote: {
+      path: null
+    }
+  }
+}
+
+/**
+ * Accept POST requests for adding domains to the internal domain configuration.
+ */
+module.exports.post = (req, res) => {
+  // Don't accept an empty POST
+  if (!req.body || (Object.keys(req.body).length === 0)) {
+    return help.sendBackJSON(400, {
+      success: false,
+      errors: ['Bad Request']
+    }, res)
+  }
+
+  let payload = req.body
+  let domains = Object.keys(payload)
+
+  domains.forEach((domain, index) => {
+    if (!DomainManager.getDomain(domain)) {
+      // Prepare the domain configuration.
+      configContent.images.remote.path = payload[domain].remote.path
+      configContent.assets.remote.path = payload[domain].remote.path
+
+      // Add the domain configuration.
+      DomainManager.addDomain(domain, configContent)
+    }
+
+    if (index === domains.length - 1) {
+      return help.sendBackJSON(201, {
+        success: true,
+        domains: DomainManager.getDomains().map(item => item.domain)
+      }, res)
+    }
+  })
+}
+
+/**
+ * Accept PUT requests for modifying domains in the internal domain configuration.
+ */
+module.exports.put = (req, res) => {
+  let domain = req.params.domain
+  let payload = req.body
+
+  // Don't accept an empty param.
+  if (!domain || !Object.keys(payload).length === 0) {
+    return help.sendBackJSON(400, {
+      success: false,
+      errors: ['Bad Request']
+    }, res)
+  }
+
+  // Domain not found.
+  if (!DomainManager.getDomain(domain)) {
+    return help.sendBackJSON(404, {
+      success: false,
+      errors: [`Domain '${domain}' does not exist`]
+    }, res)
+  }
+
+  // Prepare the domain configuration.
+  configContent.images.remote.path = payload.remote.path
+  configContent.assets.remote.path = payload.remote.path
+
+  // Update the domain configuration.
+  DomainManager.addDomain(domain, configContent)
+
+  return help.sendBackJSON(200, {
+    success: true,
+    domains: DomainManager.getDomains().map(item => item.domain)
+  }, res)
+}
+
+/**
+ * Accept DELETE requests for removing domains from the internal domain configuration.
+ */
+module.exports.delete = (req, res) => {
+  let domain = req.params.domain
+
+  // Don't accept an empty param.
+  if (!domain) {
+    return help.sendBackJSON(400, {
+      success: false,
+      errors: ['Bad Request']
+    }, res)
+  }
+
+  // Domain not found.
+  if (!DomainManager.getDomain(domain)) {
+    return help.sendBackJSON(404, {
+      success: false,
+      errors: [`Domain '${domain}' does not exist`]
+    }, res)
+  }
+
+  // Remove the domain.
+  DomainManager.removeDomain(domain)
+
+  return help.sendBackJSON(200, {
+    success: true,
+    domains: DomainManager.getDomains().map(item => item.domain)
+  }, res)
+}

--- a/dadi/lib/controller/domain.js
+++ b/dadi/lib/controller/domain.js
@@ -2,43 +2,49 @@ const path = require('path')
 const DomainManager = require(path.join(__dirname, '/../models/domain-manager'))
 const help = require(path.join(__dirname, '/../help'))
 
-// Domain configuration template.
-let configContent = {
+const configTemplate = {
   images: {
+    directory: {
+      enabled: false
+    },
     remote: {
+      enabled: true,
       path: null
     }
   },
   assets: {
+    directory: {
+      enabled: false
+    },
     remote: {
+      enabled: true,
       path: null
     }
   }
 }
-
 /**
  * Accept POST requests for adding domains to the internal domain configuration.
  */
 module.exports.post = (req, res) => {
   // Don't accept an empty POST
-  if (!req.body || (Object.keys(req.body).length === 0)) {
+  if (!req.body || !Array.isArray(req.body) || req.body.length === 0) {
     return help.sendBackJSON(400, {
       success: false,
       errors: ['Bad Request']
     }, res)
   }
 
-  let payload = req.body
-  let domains = Object.keys(payload)
+  let domains = req.body
 
-  domains.forEach((domain, index) => {
-    if (!DomainManager.getDomain(domain)) {
+  domains.forEach((item, index) => {
+    if (!DomainManager.getDomain(item.domain)) {
       // Prepare the domain configuration.
-      configContent.images.remote.path = payload[domain].remote.path
-      configContent.assets.remote.path = payload[domain].remote.path
+      let configContent = Object.assign({}, configTemplate)
+      configContent.images.remote.path = item.data.remote.path
+      configContent.assets.remote.path = item.data.remote.path
 
       // Add the domain configuration.
-      DomainManager.addDomain(domain, configContent)
+      DomainManager.addDomain(item.domain, configContent)
     }
 
     if (index === domains.length - 1) {
@@ -74,6 +80,7 @@ module.exports.put = (req, res) => {
   }
 
   // Prepare the domain configuration.
+  let configContent = Object.assign({}, configTemplate)
   configContent.images.remote.path = payload.remote.path
   configContent.assets.remote.path = payload.remote.path
 

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -188,7 +188,10 @@ const Controller = function (router) {
   })
 
   router.use('/_dadi/domains/:domain?', function (req, res, next) {
-    if (!config.get('multiDomain.enabled')) {
+    if (
+      !config.get('dadiNetwork.enableConfigurationAPI') ||
+      !config.get('multiDomain.enabled')
+    ) {
       return next()
     }
 

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -187,7 +187,11 @@ const Controller = function (router) {
     return RouteController.post(req, res)
   })
 
-  router.use('/_dadi/domains/:domain?', function (req, res) {
+  router.use('/_dadi/domains/:domain?', function (req, res, next) {
+    if (!config.get('multiDomain.enabled')) {
+      return next()
+    }
+
     return DomainController[req.method.toLowerCase()](req, res)
   })
 }

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -10,6 +10,7 @@ const urlParser = require('url')
 const zlib = require('zlib')
 
 const config = require(path.join(__dirname, '/../../../config'))
+const DomainController = require(path.join(__dirname, '/domain'))
 const help = require(path.join(__dirname, '/../help'))
 const logger = require('@dadi/logger')
 const HandlerFactory = require(path.join(__dirname, '/../handlers/factory'))
@@ -184,6 +185,10 @@ const Controller = function (router) {
 
   router.post('/api/routes', function (req, res) {
     return RouteController.post(req, res)
+  })
+
+  router.use('/_dadi/domains/:domain?', function (req, res) {
+    return DomainController[req.method.toLowerCase()](req, res)
   })
 }
 

--- a/dadi/lib/models/domain-manager.js
+++ b/dadi/lib/models/domain-manager.js
@@ -6,6 +6,41 @@ const DomainManager = function () {
 }
 
 /**
+ * Adds a domain and it's configuration to the internal domain configs.
+ *
+ * @param {String} domain
+ * @param {Object} domainConfig
+ */
+DomainManager.prototype.addDomain = function (domain, domainConfig) {
+  let config = require('./../../../config')
+
+  if (!this.getDomain(domain)) {
+    config.loadDomainConfig(domain, domainConfig)
+
+    this.domains.push({
+      domain
+    })
+  } else {
+    config.loadDomainConfig(domain, domainConfig)
+  }
+}
+
+/**
+ * Removes a domain from the internal domain configs.
+ *
+ * @param {String} domain
+ */
+DomainManager.prototype.removeDomain = function (domain) {
+  let config = require('./../../../config')
+
+  if (this.getDomain(domain)) {
+    delete config.domainConfigs[domain]
+
+    this.domains = this.domains.filter(item => item.domain !== domain)
+  }
+}
+
+/**
  * Returns a domain by name.
  *
  * @param  {String} domain

--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -127,6 +127,18 @@ HTTPStorage.prototype.get = function ({
           reject(httpError)
         }
       }
+    }).on('error', (err) => {
+      let httpError
+
+      if (err.code && err.code === 'ENOTFOUND') {
+        httpError = new Error(`Remote server not found for URL: ${this.getFullUrl()} ${err.message}`)
+      } else {
+        httpError = new Error(`ERROR: ${err.message} CODE: ${err.code}`)
+      }
+
+      httpError.statusCode = 500
+
+      reject(httpError)
     })
   })
 }

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -9,6 +9,7 @@ const request = require('supertest')
 const app = require(__dirname + '/../../dadi/lib/')
 const Cache = require(__dirname + '/../../dadi/lib/cache')
 const config = require(__dirname + '/../../config')
+const domainManager = require(__dirname + '/../../dadi/lib/models/domain-manager')
 const help = require(__dirname + '/help')
 
 const cdnUrl = `http://${config.get('server.host')}:${config.get('server.port')}`
@@ -454,6 +455,239 @@ describe('Multi-domain', function () {
             })
         })
     }).timeout(5000)
+
+    describe('internal domain management', () => {
+      it('should return 400 if no array is provided', done => {
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .end((_err, res) => {
+            res.statusCode.should.eql(400)
+            done()
+          })
+      })
+
+      it('should return 400 if a array is not provided', done => {
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send({})
+          .end((_err, res) => {
+            res.statusCode.should.eql(400)
+            done()
+          })
+      })
+
+      it('should return 400 if an empty array is provided', done => {
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send([])
+          .end((_err, res) => {
+            res.statusCode.should.eql(400)
+            done()
+          })
+      })
+
+      it('should return 201 when adding a single domain', done => {
+        let domains = [
+          {
+            domain: 'api-added-domain.com',
+            data: {
+              remote: {
+                path: 'https://google.com'
+              }
+            }
+          }
+        ]
+
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send(domains)
+          .end((_err, res) => {
+            res.statusCode.should.eql(201)
+            let domainAdded = res.body.domains.includes('api-added-domain.com')
+            domainAdded.should.eql(true)
+            done()
+          })
+      })
+
+      it('should return 201 when adding multiple domains', done => {
+        let domains = [
+          {
+            domain: 'api-added-domain-one.com',
+            data: {
+              remote: {
+                path: 'https://google.com'
+              }
+            }
+          },
+          {
+            domain: 'api-added-domain-two.com',
+            data: {
+              remote: {
+                path: 'https://google.com'
+              }
+            }
+          }
+        ]
+
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send(domains)
+          .end((_err, res) => {
+            res.statusCode.should.eql(201)
+
+            let domainsAdded = res.body.domains.includes('api-added-domain-one.com') &&
+             res.body.domains.includes('api-added-domain-two.com')
+
+            domainsAdded.should.eql(true)
+            done()
+          })
+      })
+
+      it('should return 404 when modifying a domain that doesn\'t exist', done => {
+        let domain = 'api-added-domain.com'
+        let domains = [
+          {
+            domain: domain,
+            data: {
+              remote: {
+                path: 'https://google.com'
+              }
+            }
+          }
+        ]
+
+        let update = {
+          remote: {
+            path: 'https://example.com'
+          }
+        }
+
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send(domains)
+          .end((_err, res) => {
+            res.statusCode.should.eql(201)
+            let domainAdded = res.body.domains.includes(domain)
+            domainAdded.should.eql(true)
+
+            request(cdnUrl)
+              .put('/_dadi/domains/not-a-domain')
+              .set('Host', 'testdomain.com:80')
+              .send(update)
+              .end((_err, res) => {
+                res.statusCode.should.eql(404)
+                done()
+              })
+          })
+      })
+
+      it('should return 200 when modifying a domain', done => {
+        let domain = 'api-added-domain.com'
+        let domains = [
+          {
+            domain: domain,
+            data: {
+              remote: {
+                path: 'https://google.com'
+              }
+            }
+          }
+        ]
+
+        let update = {
+          remote: {
+            path: 'https://example.com'
+          }
+        }
+
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send(domains)
+          .end((_err, res) => {
+            res.statusCode.should.eql(201)
+            let domainAdded = res.body.domains.includes(domain)
+            domainAdded.should.eql(true)
+
+            let configuredPath = config.get('images.remote.path', domain)
+            configuredPath.should.eql(domains[0].data.remote.path)
+
+            request(cdnUrl)
+              .put('/_dadi/domains/' + domain)
+              .set('Host', 'testdomain.com:80')
+              .send(update)
+              .end((_err, res) => {
+                res.statusCode.should.eql(200)
+                let domainAdded = res.body.domains.includes(domain)
+                domainAdded.should.eql(true)
+
+                configuredPath = config.get('images.remote.path', domain)
+                configuredPath.should.eql(update.remote.path)
+                done()
+              })
+          })
+      })
+
+      it('should return 404 when deleting a domain that doesn\'t exist', done => {
+        let domain = 'api-added-domain.com'
+
+        request(cdnUrl)
+          .delete('/_dadi/domains/not-a-domain')
+          .set('Host', 'testdomain.com:80')
+          .end((_err, res) => {
+            res.statusCode.should.eql(404)
+            done()
+          })
+      })
+
+      it('should return 200 when deleting a domain', done => {
+        let domain = 'api-added-domain.com'
+        let domains = [
+          {
+            domain: domain,
+            data: {
+              remote: {
+                path: 'https://google.com'
+              }
+            }
+          }
+        ]
+
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .send(domains)
+          .end((_err, res) => {
+            res.statusCode.should.eql(201)
+            let domainAdded = res.body.domains.includes(domain)
+            domainAdded.should.eql(true)
+
+            let configuredPath = config.get('images.remote.path', domain)
+            configuredPath.should.eql(domains[0].data.remote.path)
+
+            ;(typeof domainManager.getDomain(domain)).should.eql('object')
+
+            request(cdnUrl)
+              .delete('/_dadi/domains/' + domain)
+              .set('Host', 'testdomain.com:80')
+              .end((_err, res) => {
+                res.statusCode.should.eql(200)
+                let domainAdded = res.body.domains.includes(domain)
+                domainAdded.should.eql(false)
+
+               ;(typeof domainManager.getDomain(domain)).should.eql('undefined')
+
+                done()
+              })
+          })
+      })
+    })
 
     describe('when the target domain is not configured', () => {
       let testDomain = 'unknowndomain.com'

--- a/test/acceptance/multi-domain.js
+++ b/test/acceptance/multi-domain.js
@@ -248,6 +248,7 @@ describe('Multi-domain', function () {
       config.set('assets.remote.path', configBackup.assets.remote.path, 'localhost')
 
       config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
+      config.set('dadiNetwork.enableConfigurationAPI', false)
 
       help.proxyStop().then(() => {
         app.stop(done)
@@ -457,7 +458,21 @@ describe('Multi-domain', function () {
     }).timeout(5000)
 
     describe('internal domain management', () => {
+      it('should return 404 if not configured', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', false)
+
+        request(cdnUrl)
+          .post('/_dadi/domains')
+          .set('Host', 'testdomain.com:80')
+          .end((_err, res) => {
+            res.statusCode.should.eql(404)
+            done()
+          })
+      })
+
       it('should return 400 if no array is provided', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         request(cdnUrl)
           .post('/_dadi/domains')
           .set('Host', 'testdomain.com:80')
@@ -468,6 +483,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 400 if a array is not provided', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         request(cdnUrl)
           .post('/_dadi/domains')
           .set('Host', 'testdomain.com:80')
@@ -479,6 +496,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 400 if an empty array is provided', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         request(cdnUrl)
           .post('/_dadi/domains')
           .set('Host', 'testdomain.com:80')
@@ -490,6 +509,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 201 when adding a single domain', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         let domains = [
           {
             domain: 'api-added-domain.com',
@@ -514,6 +535,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 201 when adding multiple domains', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         let domains = [
           {
             domain: 'api-added-domain-one.com',
@@ -549,6 +572,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 404 when modifying a domain that doesn\'t exist', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         let domain = 'api-added-domain.com'
         let domains = [
           {
@@ -588,6 +613,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 200 when modifying a domain', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         let domain = 'api-added-domain.com'
         let domains = [
           {
@@ -635,6 +662,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 404 when deleting a domain that doesn\'t exist', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         let domain = 'api-added-domain.com'
 
         request(cdnUrl)
@@ -647,6 +676,8 @@ describe('Multi-domain', function () {
       })
 
       it('should return 200 when deleting a domain', done => {
+        config.set('dadiNetwork.enableConfigurationAPI', true)
+
         let domain = 'api-added-domain.com'
         let domains = [
           {

--- a/test/unit/domain-manager.js
+++ b/test/unit/domain-manager.js
@@ -35,7 +35,7 @@ describe('Domain manager', () => {
       })
     })
 
-    it('should ignoring any files and only include directories', () => {
+    it('should ignore any files and only include directories', () => {
       let domainsDirectory = path.resolve(
         config.get('multiDomain.directory')
       )
@@ -61,6 +61,26 @@ describe('Domain manager', () => {
       }).then(() => {
         return fs.remove(mockFile2)
       })
+    })
+  })
+
+  describe('`addDomain()` method', () => {
+    it('should add the specified domain to the internal map of domains', () => {
+      let domains = new domainManager.DomainManager()
+
+      domains.addDomain('test-domain', {})
+      domains.getDomain('test-domain').should.eql({domain: 'test-domain'})
+    })
+  })
+
+  describe('`removeDomain()` method', () => {
+    it('should remove the specified domain from the internal map of domains', () => {
+      let domains = new domainManager.DomainManager()
+
+      domains.removeDomain('test-domain')
+      let domain = domains.getDomain('test-domain');
+
+      (typeof domain).should.eql('undefined')
     })
   })
 


### PR DESCRIPTION
This PR adds support for adding/removing domain configurations from the internal configuration map.

```
# ADD alice.com
curl -i -H "content-type: application/json" -H "Authorization: Bearer XYZ" -X POST --data '[{"domain":"alice.com", "data":{"remote":{"path":"http://img.alice.com"}}}]' "http://localhost:8101/_dadi/domains"

{"success":true,"domains":["alice.com"]}

# ADD bob.com
curl -i -H "content-type: application/json" -H "Authorization: Bearer XYZ" -X POST --data '[{"domain":"bob.com", "data":{"remote":{"path":"http://img.bob.com"}}}]' "http://localhost:8101/_dadi/domains"

{"success":true,"domains":["alice.com", "bob.com"]}

# UPDATE bob.com
curl -i -H "content-type: application/json" -H "Authorization: Bearer XYZ" -X PUT --data '{"data":{"remote":{"path":"http://images.bob.com"}}}' "http://localhost:8101/_dadi/domains/bob.com"

{"success":true,"domains":["alice.com", "bob.com"]}

# DELETE alice.com
curl -i -H "content-type: application/json" -H "Authorization: Bearer XYZ" -X DELETE "http://localhost:8101/_dadi/domains/alice.com"

{"success":true,"domains":["bob.com"]}

# DELETE alice.com (again)
curl -i -H "content-type: application/json" -H "Authorization: Bearer XYZ" -X DELETE "http://localhost:8101/_dadi/domains/alice.com"

{"success":false,"errors":["Domain 'alice.com' does not exist"]}
```

Close https://github.com/dadi/internal/issues/14