### PR TITLE
Handle gzip encoding header

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -191,6 +191,13 @@ const Controller = function (router) {
   })
 }
 
+/**
+ * Determines whether the response should be compressed
+ *
+ * @param {Object} req - the original HTTP request, containing headers
+ * @param {Object} handler - the current asset handler (image, CSS, JS)
+ * @returns {Boolean} - whether to compress the data before sending the response
+ */
 Controller.prototype.shouldCompress = function (req, handler) {
   let acceptHeader = req.headers['accept-encoding'] || ''
   let contentType = handler.getContentType()

--- a/test/acceptance/cache.js
+++ b/test/acceptance/cache.js
@@ -740,7 +740,7 @@ describe('Cache', function () {
       }, 1500)
     })
 
-    it('when multi-domain is enabled, cached itemd should be kept for the period of time defined in each domain config', done => {
+    it('when multi-domain is enabled, cached items should be kept for the period of time defined in each domain config', done => {
       let mockCacheGet = sinon.spy(cache.Cache.prototype, 'getStream')
       let mockCacheSet = sinon.spy(cache.Cache.prototype, 'cacheFile')
 

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -390,7 +390,6 @@ describe('Controller', function () {
                 res.headers['content-encoding'].should.eql('gzip')
 
                 // console.log('res :', res)
-
                 config.set('headers.useGzipCompression', configBackup.headers.useGzipCompression)
 
                 done()

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -369,6 +369,68 @@ describe('Controller', function () {
       .expect('Content-Type', 'font/ttf')
       .expect(200, done)
     })
+
+    describe('gzip encoding', () => {
+      it('should return gzipped content when headers.useGzipCompression is true', done => {
+        config.set('headers.useGzipCompression', false)
+
+        request(cdnUrl)
+          .get('/css/0/test.css')
+          .end((err, res) => {
+            res.statusCode.should.eql(200)
+            should.not.exist(res.headers['content-encoding'])
+
+            config.set('headers.useGzipCompression', true)
+
+            request(cdnUrl)
+              .get('/css/0/test.css')
+              .set('Accept-Encoding', 'gzip, deflate')
+              .end((err, res) => {
+                res.statusCode.should.eql(200)
+                res.headers['content-encoding'].should.eql('gzip')
+
+                // console.log('res :', res)
+
+                config.set('headers.useGzipCompression', configBackup.headers.useGzipCompression)
+
+                done()
+              })
+          })
+      })
+
+      it('should use the value of headers.useGzipCompression defined at domain level', done => {
+        config.set('multiDomain.enabled', true)
+        config.loadDomainConfigs()
+
+        config.set('headers.useGzipCompression', true)
+        config.set('headers.useGzipCompression', false, 'localhost')
+        config.set('headers.useGzipCompression', true, 'testdomain.com')
+
+        request(cdnUrl)
+          .get('/css/0/test.css?cache=false')
+          .set('Host', 'localhost')
+          .end((err, res) => {
+            res.statusCode.should.eql(200)
+            should.not.exist(res.headers['content-encoding'])
+
+            config.set('headers.useGzipCompression', true)
+
+            request(cdnUrl)
+              .get('/css/0/test.css?cache=false')
+              .set('Host', 'testdomain.com')
+              .end((err, res) => {
+                res.statusCode.should.eql(200)
+                res.headers['content-encoding'].should.eql('gzip')
+
+                config.set('headers.useGzipCompression', configBackup.headers.useGzipCompression)
+                config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
+
+                done()
+              })
+          })
+      })
+    })
+
   })
 
   describe('HTML passthrough', function () {
@@ -1055,64 +1117,6 @@ describe('Controller', function () {
 
           done()
         })
-      })
-    })
-
-    describe.skip('gzip encoding', () => {
-      it('should return gzipped content when headers.useGzipCompression is true', done => {
-        config.set('headers.useGzipCompression', false)
-
-        request(cdnUrl)
-          .get('/test.jpg')
-          .end((err, res) => {
-            res.statusCode.should.eql(200)
-            should.not.exist(res.headers['content-encoding'])
-
-            config.set('headers.useGzipCompression', true)
-
-            request(cdnUrl)
-              .get('/test.jpg')
-              .end((err, res) => {
-                res.statusCode.should.eql(200)
-                res.headers['content-encoding'].should.eql('gzip')
-
-                config.set('headers.useGzipCompression', configBackup.headers.useGzipCompression)
-
-                done()
-              })
-          })
-      })
-
-      it('should use the value of headers.useGzipCompression defined at domain level', done => {
-        config.set('multiDomain.enabled', true)
-        config.loadDomainConfigs()
-
-        config.set('headers.useGzipCompression', true)
-        config.set('headers.useGzipCompression', false, 'localhost')
-        config.set('headers.useGzipCompression', true, 'testdomain.com')
-
-        request(cdnUrl)
-          .get('/test.jpg')
-          .set('Host', 'localhost')
-          .end((err, res) => {
-            res.statusCode.should.eql(200)
-            should.not.exist(res.headers['content-encoding'])
-
-            config.set('headers.useGzipCompression', true)
-
-            request(cdnUrl)
-              .get('/test.jpg')
-              .set('Host', 'testdomain.com')
-              .end((err, res) => {
-                res.statusCode.should.eql(200)
-                res.headers['content-encoding'].should.eql('gzip')
-
-                config.set('headers.useGzipCompression', configBackup.headers.useGzipCompression)
-                config.set('multiDomain.enabled', configBackup.multiDomain.enabled)
-
-                done()
-              })
-          })
       })
     })
 

--- a/test/acceptance/controller.js
+++ b/test/acceptance/controller.js
@@ -389,7 +389,6 @@ describe('Controller', function () {
                 res.statusCode.should.eql(200)
                 res.headers['content-encoding'].should.eql('gzip')
 
-                // console.log('res :', res)
                 config.set('headers.useGzipCompression', configBackup.headers.useGzipCompression)
 
                 done()


### PR DESCRIPTION
This PR tests the Accept-Encoding request header in a more sensible manner, allowing for a comma-separated string of accepted encodings.

In addition, it adds tests for gzipping a CSS file, rather than testing for images being gzipped which shouldn't be possible due to the response from module `compressible` which indicates if a particular MIME type should be compressible.