### PR TITLE
Wait for response to end

### DIFF
--- a/dadi/lib/storage/http.js
+++ b/dadi/lib/storage/http.js
@@ -63,64 +63,69 @@ HTTPStorage.prototype.get = function ({
       res.on('end', () => {
         let statusCode = res.statusCode
 
+        // Successful response, return the data
         if (statusCode === 200) {
           return resolve(streamifier.createReadStream(Buffer.concat(buffers)))
-        } else {
-          if (
-            [301, 302, 307].includes(statusCode) &&
-            typeof res.headers.location === 'string'
-          ) {
-            let parsedRedirectUrl = url.parse(res.headers.location)
+        }
 
-            parsedRedirectUrl.host = parsedRedirectUrl.host || parsedUrl.host
-            parsedRedirectUrl.port = parsedRedirectUrl.port || parsedUrl.port
-            parsedRedirectUrl.protocol = parsedRedirectUrl.protocol || parsedUrl.protocol
+        // Determine what to do with the response when not successful. If it's
+        // a redirect status code, we continue trying to get it until we reach the
+        // configured redirect limit.
+        if (
+          [301, 302, 307].includes(statusCode) &&
+          typeof res.headers.location === 'string'
+        ) {
+          let parsedRedirectUrl = url.parse(res.headers.location)
 
-            if (redirects < config.get('http.followRedirects', this.domain)) {
-              return resolve(
-                this.get({
-                  redirects: redirects + 1,
-                  requestUrl: url.format(parsedRedirectUrl)
-                })
-              )
-            }
+          parsedRedirectUrl.host = parsedRedirectUrl.host || parsedUrl.host
+          parsedRedirectUrl.port = parsedRedirectUrl.port || parsedUrl.port
+          parsedRedirectUrl.protocol = parsedRedirectUrl.protocol || parsedUrl.protocol
 
-            // We've hit the maximum number of redirects allowed, so we'll
-            // treat this as a 404.
-            statusCode = 404
+          if (redirects < config.get('http.followRedirects', this.domain)) {
+            return resolve(
+              this.get({
+                redirects: redirects + 1,
+                requestUrl: url.format(parsedRedirectUrl)
+              })
+            )
           }
 
-          let httpError
+          // We've hit the maximum number of redirects allowed, so we'll
+          // treat this as a 404.
+          statusCode = 404
+        }
 
-          switch (statusCode) {
-            case 404:
-              httpError = new Error(`Not Found: ${this.getFullUrl()}`)
+        // It's not a redirect, determine what to return
+        let httpError
 
-              break
-            case 403:
-              httpError = new Error(`Forbidden: ${this.getFullUrl()}`)
+        switch (statusCode) {
+          case 404:
+            httpError = new Error(`Not Found: ${this.getFullUrl()}`)
 
-              break
-            default:
-              httpError = new Error(`Remote server responded with error code ${statusCode} for URL: ${this.getFullUrl()}`)
-          }
+            break
+          case 403:
+            httpError = new Error(`Forbidden: ${this.getFullUrl()}`)
 
-          httpError.statusCode = statusCode
+            break
+          default:
+            httpError = new Error(`Remote server responded with error code ${statusCode} for URL: ${this.getFullUrl()}`)
+        }
 
-          if (statusCode === 404) {
-            new Missing().get({
-              domain: this.domain,
-              isDirectory: path.parse(this.getFullUrl()).ext === ''
-            }).then(stream => {
-              this.notFound = true
-              this.lastModified = new Date()
-              resolve(stream)
-            }).catch(() => {
-              reject(httpError)
-            })
-          } else {
+        httpError.statusCode = statusCode
+
+        if (statusCode === 404) {
+          new Missing().get({
+            domain: this.domain,
+            isDirectory: path.parse(this.getFullUrl()).ext === ''
+          }).then(stream => {
+            this.notFound = true
+            this.lastModified = new Date()
+            resolve(stream)
+          }).catch(() => {
             reject(httpError)
-          }
+          })
+        } else {
+          reject(httpError)
         }
       })
     }).on('error', (err) => {


### PR DESCRIPTION
This PR modifies the HTTP storage handler to ensure the response ends completely for all status codes, before taking action based on the returned status code. The existing behaviour is to only finish a response if an HTTP 200 is returned.