### PR TITLE
Set content length header after gzip

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -75,25 +75,24 @@ const Controller = function (router) {
       }
 
       let etagResult = etag(data)
-      let contentLength = Buffer.isBuffer(data)
-        ? data.byteLength
-        : data.length
-
       res.setHeader('ETag', etagResult)
 
       if (this.shouldCompress(req, handler)) {
         res.setHeader('Content-Encoding', 'gzip')
-        res.setHeader('Transfer-Encoding', 'chunked')
 
         data = new Promise((resolve, reject) => {
           zlib.gzip(data, (err, compressedData) => {
             if (err) return reject(err)
 
+            res.setHeader('Content-Length', compressedData.byteLength)
             resolve(compressedData)
           })
         })
       } else {
-        res.setHeader('Content-Length', contentLength)
+        res.setHeader(
+          'Content-Length',
+          Buffer.isBuffer(data) ? data.byteLength : data.length
+        )
       }
 
       return Promise.resolve(data).then(data => {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -79,11 +79,11 @@ const Controller = function (router) {
         ? data.byteLength
         : data.length
 
-      res.setHeader('Content-Length', contentLength)
       res.setHeader('ETag', etagResult)
 
       if (this.shouldCompress(req, handler)) {
         res.setHeader('Content-Encoding', 'gzip')
+        res.setHeader('Transfer-Encoding', 'chunked')
 
         data = new Promise((resolve, reject) => {
           zlib.gzip(data, (err, compressedData) => {
@@ -92,6 +92,8 @@ const Controller = function (router) {
             resolve(compressedData)
           })
         })
+      } else {
+        res.setHeader('Content-Length', contentLength)
       }
 
       return Promise.resolve(data).then(data => {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "babel-preset-env": "1.6.1",
     "babel-preset-minify": "0.5.0",
     "body-parser": "^1.18.2",
-    "busboy": "^0.2.13",
     "chokidar": "^2.0.3",
     "cloudfront": "~0.4.0",
     "color-namer": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "should": "~13.2.0",
     "sinon": "^4.0.2",
     "standard": "8.x.x",
-    "supertest": "~3.2.0"
+    "superagent": "^4.1.0",
+    "supertest": "^3.4.2"
   },
   "greenkeeper": {
     "ignore": [

--- a/test/acceptance/visual.js
+++ b/test/acceptance/visual.js
@@ -58,7 +58,6 @@ function requestTestImage (test) {
   return Jimp
     .read(baselineImagePath)
     .then(baselineImage => {
-      console.log('baselineImage :', baselineImage)
       return Jimp
         .read(cdnUrl + requestPath)
         .then(testImage => {


### PR DESCRIPTION
The browser doesn't know when the response is ending because we are setting the content length before gzipping, so the browser thinks there is more to come. This PR sets the content length after gzipping.

Fix #479